### PR TITLE
Modernize profile page styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ result
 .devenv
 .devenv
 pg-init-*
+.claude
+.parcel-cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .direnv
 result
 .devenv
-.devenv
 pg-init-*
 CLAUDE.md
 .claude

--- a/backend/lib/Types.hs
+++ b/backend/lib/Types.hs
@@ -183,7 +183,7 @@ instance FromBackendRow Pg.Postgres Feature
 
 featureDescription :: Feature -> Text
 featureDescription GroupStudy =
-  "(In Development) Study together in groups!"
+  "Group Studies (Beta)"
 featureDescription Unknown =
   "Features we remove will be caught be this one."
 

--- a/backend/static/styles/pages/profile.css
+++ b/backend/static/styles/pages/profile.css
@@ -70,7 +70,7 @@ html, body {
 .profileCard {
   background: #fff;
   border-radius: 9px;
-  box-shadow: 0 4px 7px 1px #00000012;
+  box-shadow: 0 4px 7px 1px rgba(0,0,0,0.07);
   padding: 24px 28px;
 
   h2 {
@@ -96,7 +96,7 @@ html, body {
       margin-bottom: 12px;
     }
 
-    div {
+    .checkboxRow {
       display: flex;
       align-items: center;
       gap: 8px;

--- a/backend/static/styles/pages/profile.css
+++ b/backend/static/styles/pages/profile.css
@@ -1,25 +1,116 @@
 @import url("../utils/base.css");
 @import url("../component/nav.css");
 
+html, body {
+  overflow: hidden;
+  height: 100%;
+  margin: 0;
+}
+
+#profileScroll {
+  height: calc(100vh - 52px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+#profileScroll #footer {
+  margin-top: auto;
+}
+
+.profileHeader {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  max-width: 500px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 44px 28px 0;
+  box-sizing: border-box;
+}
+
+.profileAvatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: #fff;
+  color: var(--blue-100);
+  font-weight: 700;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  flex-shrink: 0;
+}
+
+.profileHeaderInfo h1 {
+  font-size: 20px;
+  margin: 0;
+}
+
+.profileHeaderInfo p {
+  margin: 2px 0 0;
+  font-size: 13px;
+  color: #666;
+}
 
 #profileContent {
-  margin-top: 10px;
-  display: grid;
-  justify-content: center;
-  h1 {
-    font-size: 27px;
+  max-width: 500px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 30px 28px 44px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  flex: 1;
+}
+
+.profileCard {
+  background: #fff;
+  border-radius: 9px;
+  box-shadow: 0 4px 7px 1px #00000012;
+  padding: 24px 28px;
+
+  h2 {
+    font-size: 18px;
+    margin: 0 0 16px;
   }
+
   form {
-    max-width: 400px;
     flex-direction: column;
     align-items: stretch;
     width: 100%;
-    margin-top: 20px;
     display: flex;
+
     label {
       color: #666;
-      margin-bottom: 5px;
-      font-size: 14px;
+      margin-bottom: 4px;
+      font-size: 13px;
+    }
+
+    input[type="text"],
+    input[type="email"] {
+      padding: 8px 12px;
+      margin-bottom: 12px;
+    }
+
+    div {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+
+      label {
+        margin-bottom: 0;
+        font-size: 14px;
+      }
+    }
+
+    button[type="submit"] {
+      width: 100%;
+      margin-top: 4px;
     }
   }
 }

--- a/backend/static/styles/utils/button.css
+++ b/backend/static/styles/utils/button.css
@@ -41,7 +41,7 @@ button.blue {
   }
   &:disabled {
     background-color: var(--blue-75);
-    border: 2px solid var(--red-50);
+    cursor: default;
   }
 }
 

--- a/backend/templates/profile.html
+++ b/backend/templates/profile.html
@@ -46,19 +46,32 @@
   </menu>
 </dialog>
 
-<div id="profileContent">
-  <h1>My Profile</h1>
-  {% include "profile/form.html" %}
+<div id="profileScroll">
+  <div class="profileHeader">
+    <div class="profileAvatar">{{user.nameShort}}</div>
+    <div class="profileHeaderInfo">
+      <h1>{{user.name}}</h1>
+      <p>{{user.email}}</p>
+    </div>
+  </div>
 
-  <br>
-  <h1>Features</h1>
-  {% include "profile/featureForm.html" %}
+  <div id="profileContent">
+    <div class="profileCard">
+      <h2>Profile Info</h2>
+      {% include "profile/form.html" %}
+    </div>
+
+    <div class="profileCard">
+      <h2>Features</h2>
+      {% include "profile/featureForm.html" %}
+    </div>
+  </div>
+
+  {% include "footer.html" %}
 </div>
 
 <script>
   {% include "scripts/inputs.js" %}
 </script>
-
-{% include "footer.html" %}
 
 {% endblock %}

--- a/backend/templates/profile.html
+++ b/backend/templates/profile.html
@@ -72,6 +72,37 @@
 
 <script>
   {% include "scripts/inputs.js" %}
+
+  function formSnapshot(form) {
+    return new FormData(form);
+  }
+
+  function snapshotsEqual(a, b) {
+    const aEntries = [...a.entries()].sort().toString();
+    const bEntries = [...b.entries()].sort().toString();
+    return aEntries === bEntries;
+  }
+
+  function initFormDirtyTracking(form) {
+    const btn = form.querySelector('button[type="submit"]');
+    if (!btn) return;
+    const baseline = formSnapshot(form);
+    function update() {
+      btn.disabled = snapshotsEqual(baseline, formSnapshot(form));
+    }
+    form.addEventListener("input", update);
+    form.addEventListener("change", update);
+  }
+
+  function initAllForms() {
+    document.querySelectorAll(".profileCard form").forEach(initFormDirtyTracking);
+  }
+
+  window.addEventListener("load", initAllForms);
+  document.addEventListener("htmx:afterSwap", (e) => {
+    const form = e.target.closest && e.target.closest("form") || e.target.querySelector && e.target.querySelector("form");
+    if (form) initFormDirtyTracking(form);
+  });
 </script>
 
 {% endblock %}

--- a/backend/templates/profile/featureForm.html
+++ b/backend/templates/profile/featureForm.html
@@ -1,7 +1,7 @@
 <form hx-post="{{base}}/profile/feature" hx-target="this" hx-swap="outerHTML">
   {% for feature in allFeatures %}
     {% if feature.feature != "Unknown" %}
-    <div>
+    <div class="checkboxRow">
       <input
         type="checkbox"
         id="{{feature.feature}}"

--- a/backend/templates/profile/featureForm.html
+++ b/backend/templates/profile/featureForm.html
@@ -11,7 +11,7 @@
         {% endif %}
       >
       <label for="{{feature.feature}}">
-        {{feature.feature}} - {{feature.description}}
+        {{feature.description}}
       </label>
 
     </div>

--- a/backend/templates/profile/featureForm.html
+++ b/backend/templates/profile/featureForm.html
@@ -22,6 +22,6 @@
       Saved!
     </p-notification>
   {% endif %}
-  <button class="blue" type="submit">Save</button>
+  <button class="blue" type="submit" disabled>Save</button>
 
 </form>

--- a/backend/templates/profile/form.html
+++ b/backend/templates/profile/form.html
@@ -1,8 +1,8 @@
 <form hx-put="{{base}}/profile" hx-target="this" hx-swap="outerHTML">
-    <label for="name">Name</label>
-    <input value="{{user.name}}" name="name" type="text" required>
-    <label for="name">Email</label>
-    <input name="email" type="email" value="{{user.email}}" required>
+    <label for="profileName">Name</label>
+    <input id="profileName" value="{{user.name}}" name="name" type="text" required>
+    <label for="profileEmail">Email</label>
+    <input id="profileEmail" name="email" type="email" value="{{user.email}}" required>
     {% if wasSaved %}
       <p-notification time-ms="1000">
         Saved!

--- a/backend/templates/profile/form.html
+++ b/backend/templates/profile/form.html
@@ -8,5 +8,5 @@
         Saved!
       </p-notification>
     {% endif %}
-    <button class="blue" type="submit">Save</button>
+    <button class="blue" type="submit" disabled>Save</button>
 </form>


### PR DESCRIPTION
Redesigns the profile page with a card-based layout, an avatar header showing the user's name and email, and constrained-width content area. Save buttons are disabled until the user actually changes something.

## Layout & scroll

- **`html, body { overflow: hidden }`**: The scroll container is `#profileScroll` (not the body), so this prevents a double scrollbar — one from the browser and one from the inner div.
- **`height: calc(100vh - 52px)`**: The 52px accounts for the fixed nav height so the scroll area fills exactly the remaining viewport.
- **Footer moved inside `#profileScroll`**: Keeps the footer at the bottom of the scroll container (`margin-top: auto`) rather than below it.

## Dirty-tracking (Save button enabled state)

- **Buttons start `disabled` in the template**: Guarantees they're inactive even before JS runs, avoiding a flash of an enabled button on load.
- **`FormData` snapshot as baseline**: Captures text inputs and checkboxes uniformly without manually enumerating fields; works for both forms with a single approach.
- **`window load` (not `DOMContentLoaded`)**: `inputs.js` (also on `load`) resets input values from their HTML attributes to work around HTMX re-use quirks — our snapshot must run after that, and same-event listeners fire in registration order.
- **`htmx:afterSwap` re-init**: After a successful save HTMX replaces the form's outerHTML; the new form's saved values become the new baseline so the button returns to disabled.
- **`cursor: default` on `button.blue:disabled`**: The previous `not-allowed` cursor and red border were jarring for a "nothing has changed yet" state; the lighter blue background alone is sufficient to indicate the button is inactive.

## Other

- **Label `for` fix**: Both labels previously pointed to `for="name"` with no matching `id`; clicking "Email" would have focused the name input. Prefixed ids (`profileName`, `profileEmail`) avoid any collision with other forms on the page.
- **`checkboxRow` class**: Replaced the ambient `.profileCard form div` selector (which would match any future div inside a card form) with an explicit opt-in class.
- **Feature label**: Removed the raw enum name prefix (`GroupStudy - …`) from the feature toggle label; the description alone is sufficient now that it reads "Group Studies (Beta)".