### PR TITLE
Fix typos, update copy, and polish UI text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ result
 .devenv
 .devenv
 pg-init-*
+.claude
+.parcel-cache

--- a/backend/lib/Api/Htmx/GroupStudy.hs
+++ b/backend/lib/Api/Htmx/GroupStudy.hs
@@ -521,7 +521,7 @@ createPeopleTemplate = do
       L.input_
         [ L.name_ "email[]"
         , L.type_ "email"
-        , L.placeholder_ "jonny@p215.church"
+        , L.placeholder_ "name@example.com"
         ]
       L.pSelect_ [ L.name_ "permission[]"] $ do
         L.option_ [ L.value_ "member"] "Member"

--- a/backend/templates/footer.html
+++ b/backend/templates/footer.html
@@ -7,6 +7,6 @@
     {% endif %}
     <li><a href="mailto:support@p215.church">Contact Us</a></li>
   </menu>
-  <p class="copyright">Copyright © 2024 Hope Community Church. All Rights Reserved.</p>
+  <p class="copyright">Copyright © 2025 Hope Community Church. All Rights Reserved.</p>
 </footer>
 

--- a/backend/templates/profile.html
+++ b/backend/templates/profile.html
@@ -51,7 +51,7 @@
   {% include "profile/form.html" %}
 
   <br>
-  <h1>Features</h1>
+  <h1>Beta Features</h1>
   {% include "profile/featureForm.html" %}
 </div>
 

--- a/backend/templates/studies.html
+++ b/backend/templates/studies.html
@@ -167,7 +167,7 @@
     <label for="studyTitle">Title</label>
     <input type="text" required name="studyTitle" placeholder="New Title...">
     <p class="fieldDescription">
-      Ex: "<em>Romans January 2024 Study</em>"
+      Ex: "<em>Romans Study</em>"
       or "<em>Wednesday Night Colossians Study</em>"
     </p>
     <button type="submit" class="blue">

--- a/backend/templates/study.html
+++ b/backend/templates/study.html
@@ -142,10 +142,10 @@
     <p class="divider">|</p>
     <div id="saveThingy" class="notSaving">
       <p id="saved" class="saveThing">
-        saved <img src="{{base}}/static/img/saved.svg" >
+        Saved <img src="{{base}}/static/img/saved.svg" >
       </p>
       <p id="saving" class="saveThing">
-        saving <img src="{{base}}/static/img/saving.svg" >
+        Saving... <img src="{{base}}/static/img/saving.svg" >
       </p>
     </div>
     <menu class="menu">
@@ -206,8 +206,8 @@
 
 
   <dialog id="confirmDelete">
-    <h3>Are you sure?</h3>
-    <p>Are you sure you want to delete your study?</p>
+    <h3>Delete Study</h3>
+    <p>Are you sure? This action is permanent and cannot be undone.</p>
     <div>
       <button class="lightBlue" onclick="toggleModal('#confirmDelete')">
         Cancel
@@ -331,7 +331,7 @@
       <header>
         <h2>Edit Study Blocks</h2>
         <div style="color:gray">
-          Click and grad to move the study blocks around.
+          Click and drag to reorder study blocks.
         </div>
       </header>
       <div id="studyBlockEditorContent">

--- a/frontend/src/Editor/editorUtils.tsx
+++ b/frontend/src/Editor/editorUtils.tsx
@@ -207,8 +207,7 @@ export const addGeneralStudyBlock = (state: EditorState, dispatch?: (tr: Transac
     // Create the nodes for the new study block
     const header = textSchema.text("Untitled");
     const sbHeader = textSchema.nodes.generalStudyBlockHeader.createChecked(null, header);
-    const bodytxt = textSchema.text("my stuff here");
-    const bodyp = textSchema.nodes.paragraph.createChecked(null, bodytxt);
+    const bodyp = textSchema.nodes.paragraph.createChecked();
     const sbBody = textSchema.nodes.generalStudyBlockBody.create(null, bodyp);
 
     const newStudyBlockId = uuidv4();


### PR DESCRIPTION
Fixes stale copy, capitalisation, and placeholder text across the app. No logic changes.

## Reviewer Notes

**New study block content**
Removes the accidental placeholder text `"my stuff here"` that was shipping inside every newly created study block — it was debug/dev scaffolding that was never meant to reach production.

**Email placeholder**
Swaps the internal `jonny@p215.church` address for the generic `name@example.com` so it doesn't look like a required format to users.

**Study title example**
Removed the hardcoded `January 2024` date from the example hint; it was already stale and would only get worse over time.

**Delete dialog**
Previous copy said "Are you sure?" twice (header + body). New copy uses "Delete Study" as the header and adds explicit permanence warning in the body.

**Save indicator**
Capitalised "saved"/"saving" and added ellipsis to "Saving..." to match standard UI conventions.

**Beta Features**
Renamed section from "Features" to "Beta Features" to set correct user expectations.