### PR TITLE
Redesign study block editor UI with drag-and-drop, add/rename, and group study modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .direnv
 result
 .devenv
-.devenv
 pg-init-*
 CLAUDE.md
 .claude

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ result
 .devenv
 pg-init-*
 CLAUDE.md
+.claude/
+.parcel-cache/

--- a/backend/lib/Api/Htmx/GroupStudy.hs
+++ b/backend/lib/Api/Htmx/GroupStudy.hs
@@ -17,6 +17,7 @@ import Entity.User qualified as User
 import EnvFields (HasUrl)
 import Fields.Email (mkEmail)
 import Lucid qualified as L
+import Lucid.Base (makeAttribute)
 import Lucid.Htmx qualified as L
 import Mail qualified
 import Network.HTTP.Types.Status (status200)
@@ -93,12 +94,13 @@ createStudyGroupHTML
   -> L.HtmlT m ()
 createStudyGroupHTML doc = do
   L.div_ [L.class_ "groupStudyInner"] $ do
-    L.img_
-      [ L.alt_ "Close"
-      , L.src_ "/static/img/x.svg"
-      , L.class_ "closeModalIcon"
+    L.button_
+      [ L.class_ "closeModalIcon"
       , L.onclick_ "toggleModal('#groupStudy')"
+      , L.type_ "button"
+      , makeAttribute "aria-label" "Close"
       ]
+      (L.img_ [L.src_ "/static/img/x.svg", L.alt_ ""])
     L.h3_ "Create Group Study"
     L.p_ [L.class_ "field-desc"]
       "A group study lets multiple people work through the same study template together, each with their own document."
@@ -244,12 +246,13 @@ groupStudyHTML
 groupStudyHTML user isOwner shares groupStudy = do
   let groupIdTxt = UUID.toText (unwrap groupStudy.groupStudyId)
   L.div_ [ L.class_ "groupStudyEditorHolder" , L.id_ "groupStudyInner" ] $ do
-    L.img_
-      [ L.alt_ "Close"
-      , L.src_ "/static/img/x.svg"
-      , L.class_ "closeModalIcon"
+    L.button_
+      [ L.class_ "closeModalIcon"
       , L.onclick_ "toggleModal('#groupStudy')"
+      , L.type_ "button"
+      , makeAttribute "aria-label" "Close"
       ]
+      (L.img_ [L.src_ "/static/img/x.svg", L.alt_ ""])
 
     -- Header
     L.div_ [L.class_ "groupStudy-header"] $ do
@@ -556,17 +559,6 @@ ownershipMemberDoc user = do
 
 
 
-getInvite
-  :: ( MonadDb env m
-     , MonadLogger m
-     )
-  => AuthUser
-  -> ActionT m ()
-getInvite _ = do
-  groupId <- captureParam "groupId"
-  html =<< L.renderTextT (getInviteNewMemberHTML groupId)
-
-
 createPeopleTemplate :: Monad m => L.HtmlT m ()
 createPeopleTemplate = do
   L.template_ [L.id_ "peopleInputTemplate"] $ do
@@ -580,28 +572,6 @@ createPeopleTemplate = do
         L.option_ [ L.value_ "member"] "Member"
         L.option_ [ L.value_ "owner"] "Owner"
       L.button_ [L.class_ "red"] "-"
-
-
-getInviteNewMemberHTML
-  :: Monad m
-  => T.GroupStudyId
-  -> L.HtmlT m ()
-getInviteNewMemberHTML groupId = do
-  L.div_ [L.class_ "groupStudyInner"] $ do
-    L.h3_ "Invite New People"
-    let formUrl = "/group_study/invite/add"
-    L.form_ [ L.hxPost_ formUrl, L.class_ "groupStudyEditorHolder", L.hxTarget_ "#groupStudyInner"] $ do
-      L.input_
-        [ L.id_ "groupId"
-        , L.name_ "groupId"
-        , L.type_ "hidden"
-        , L.value_ (UUID.toText (unwrap groupId))
-        ]
-      L.label_ [L.for_ "createPeople"] "People"
-      L.div_ [L.id_ "createPeoples"] createPeopleTemplate
-      L.button_ [L.type_ "submit", L.class_ "blue"]
-        "Invite"
-  L.script_ "addPeopleInput()";
 
 
 postInvite

--- a/backend/lib/Api/Htmx/Server.hs
+++ b/backend/lib/Api/Htmx/Server.hs
@@ -185,9 +185,6 @@ scottyServer = do
     Scotty.post "/group_study/:groupId/member/:docId/ownership" $ do
       user <- getUserWithRedirect
       GroupStudy.ownershipMemberDoc user
-    Scotty.get "/group_study/invite/:groupId" $ do
-      user <- getUserWithRedirect
-      GroupStudy.getInvite user
     Scotty.post "/group_study/invite/add" $ do
       user <- getUserWithRedirect
       GroupStudy.postInvite user

--- a/backend/static/img/gray-pencil-in-circle.svg
+++ b/backend/static/img/gray-pencil-in-circle.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
   <g id="button.edit" transform="translate(-352.981 -389.981)">
-    <rect id="Rectangle_7" data-name="Rectangle 7" width="40" height="40" rx="20" transform="translate(352.981 389.981)" fill="#ebebeb"/>
+    <rect id="Rectangle_7" data-name="Rectangle 7" width="40" height="40" rx="20" transform="translate(352.981 389.981)" fill="none"/>
     <g id="Group_6504" data-name="Group 6504">
-      <path id="edit-2" d="M13.693,2.817a2.2,2.2,0,0,1,3.118,3.118L6.287,16.459,2,17.628l1.169-4.287Z" transform="translate(363.252 400.081)" fill="none" stroke="#3f464d" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"/>
-      <path id="Path_4828" data-name="Path 4828" d="M377.946,407.993l-3.265-3.1" fill="none" stroke="#3f464d" stroke-width="2"/>
+      <path id="edit-2" d="M13.693,2.817a2.2,2.2,0,0,1,3.118,3.118L6.287,16.459,2,17.628l1.169-4.287Z" transform="translate(363.252 400.081)" fill="none" stroke="#0057d1" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"/>
+      <path id="Path_4828" data-name="Path 4828" d="M377.946,407.993l-3.265-3.1" fill="none" stroke="#0057d1" stroke-width="2"/>
     </g>
   </g>
 </svg>

--- a/backend/static/styles/component/groupstudy.css
+++ b/backend/static/styles/component/groupstudy.css
@@ -13,11 +13,16 @@
 
   .closeModalIcon {
     cursor: pointer;
-    max-width: 20px;
+    background: none;
+    border: none;
     padding: 10px;
     position: absolute;
     top: 12px;
     right: 12px;
+    line-height: 0;
+    img {
+      width: 20px;
+    }
   }
 
   .field-label {

--- a/backend/static/styles/component/newstudy.css
+++ b/backend/static/styles/component/newstudy.css
@@ -22,11 +22,16 @@
 
 #newStudy .closeModalIcon {
   cursor: pointer;
-  max-width: 20px;
+  background: none;
+  border: none;
   padding: 10px;
   position: absolute;
   top: 20px;
   right: 10px;
+  line-height: 0;
+  img {
+    width: 20px;
+  }
 }
 
 #newStudy label {

--- a/backend/static/styles/editor/editor.css
+++ b/backend/static/styles/editor/editor.css
@@ -388,10 +388,19 @@ img.ProseMirror-separator {
       right: 0;
       cursor: pointer;
       z-index: 2;
-      max-width: 28px;
-      transform: translate(13px, -9px);
-      box-shadow: 0 0 4px #00000049;
-      border-radius: 50%;
+      transform: translateX(8px);
+      top: -17px;
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      padding: 3px 10px 3px 4px;
+      border-radius: 18px;
+      font-size: 13px;
+      box-shadow: 0 1px 3px #00000020;
+      img {
+        width: 22px;
+        transform: scale(1.26);
+      }
     }
 
     .studyBlocks {

--- a/backend/static/styles/editor/editor.css
+++ b/backend/static/styles/editor/editor.css
@@ -398,8 +398,7 @@ img.ProseMirror-separator {
       font-size: 13px;
       box-shadow: 0 1px 3px #00000020;
       img {
-        width: 22px;
-        transform: scale(1.26);
+        width: 28px;
       }
     }
 

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -163,52 +163,162 @@
 
 
 #studyBlockEditor{
-  width: 60vw;
-  min-height: 60vh;
-  padding: 10px;
+  max-width: 520px;
+  width: 90%;
+  padding: 20px;
+  position: relative;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px #0000001a;
+  overflow: visible;
+
+  .closeModalIcon {
+    cursor: pointer;
+    max-width: 20px;
+    padding: 10px;
+    position: absolute;
+    top: 20px;
+    right: 10px;
+  }
+
   .container {
     display: grid;
-    overflow-x: hidden;
-    grid-template-rows: 4em 1fr 3em;
-    height: 60vh;
+    overflow: visible;
+    grid-template-rows: auto 1fr auto;
+
+    header {
+      padding-bottom: 12px;
+      border-bottom: 1px solid #e5e5e5;
+      margin-bottom: 12px;
+      padding-right: 40px;
+    }
+
     h2 {
       padding: 0px;
       margin: 0px;
     }
 
+    .subtitle {
+      color: #888;
+      font-size: 14px;
+      margin-top: 4px;
+    }
+
     #studyBlockEditorContent {
-      padding: 10px;
+      padding: 4px 0;
+      position: relative;
+      overflow: visible;
+      .dropPlaceholder {
+        border-radius: 6px;
+        background: #e8eeff;
+        border: 2px dashed #b0c4ff;
+        box-sizing: border-box;
+        transition: height 0.15s ease;
+      }
       .moving {
-        opacity: 0.5;
-        background-color: #e9e9e9;
-        transform: scale(1.1);
-        transition: transform 0.2s cubic-bezier(.6,1.36,0,1.99);
+        background-color: #eef2ff !important;
+        box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+        z-index: 10;
+        position: absolute;
+        width: 100%;
+        transition: none !important;
+      }
+      .swapping {
+        transition: transform 0.2s ease;
       }
       .studyBlock {
         transform-origin: left;
-        font-size: 1.5em;
+        font-size: 1.1em;
         user-select: none;
-        cursor: move;
-        padding: 2px;
-        grid-template-columns: 1fr 30px;
+        padding: 8px 10px;
+        border-radius: 6px;
+        cursor: grab;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+        grid-template-columns: 20px 1fr 30px;
         display: grid;
+        align-items: center;
+        gap: 8px;
+        border-bottom: 1px solid #f0f0f0;
+
+        .dragHandle {
+          width: 16px;
+          opacity: 0.9;
+          cursor: grab;
+        }
+
         .remove {
-          color: rgb(117, 117, 117);
           cursor: pointer;
+          width: 14px;
+          padding: 4px;
+          opacity: 0.9;
+          justify-self: center;
+          border-radius: 4px;
           &:hover {
-            color: rgb(48, 48, 48);
+            opacity: 1;
           }
         }
       }
       .studyBlock {
         &:hover {
-          background-color: #e9e9e9;
+          background-color: #f6f6f6;
+        }
+      }
+    }
+
+    #studyBlockEditorRemoved {
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid #e5e5e5;
+
+      .removedHeader {
+        font-size: 13px;
+        color: #888;
+        margin-bottom: 6px;
+      }
+
+      .studyBlock {
+        opacity: 0.5;
+        cursor: default;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        padding: 8px 10px;
+        border-radius: 6px;
+        font-size: 1.1em;
+        &:hover {
+          background-color: #f6f6f6;
+          opacity: 0.7;
+        }
+        .restore {
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          gap: 4px;
+          opacity: 1;
+          font-size: 13px;
+          color: #444;
+          padding: 4px 10px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          background: #fff;
+          img {
+            width: 18px;
+          }
+          &:hover {
+            background-color: #f0f0f0;
+            border-color: #aaa;
+          }
         }
       }
     }
 
     footer {
-      margin-top: 10px;
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid #e5e5e5;
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
     }
 
   }

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -240,6 +240,10 @@
         gap: 8px;
         border-bottom: 1px solid #f0f0f0;
 
+        &:hover {
+          background-color: #f6f6f6;
+        }
+
         .dragHandle {
           width: 16px;
           opacity: 0.9;
@@ -256,11 +260,6 @@
           &:hover {
             opacity: 1;
           }
-        }
-      }
-      .studyBlock {
-        &:hover {
-          background-color: #f6f6f6;
         }
       }
     }

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -227,7 +227,6 @@
         transition: transform 0.2s ease;
       }
       .studyBlock {
-        transform-origin: left;
         font-size: 1.1em;
         user-select: none;
         padding: 8px 10px;

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -163,7 +163,7 @@
 
 
 #studyBlockEditor{
-  max-width: 520px;
+  max-width: 800px;
   width: 90%;
   padding: 20px;
   position: relative;
@@ -234,15 +234,13 @@
       .studyBlock {
         font-size: 1.1em;
         user-select: none;
-        padding: 8px 10px;
-        border-radius: 6px;
+        padding: 0 6px;
         cursor: grab;
         transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
         grid-template-columns: 20px 1fr 30px;
         display: grid;
-        align-items: center;
+        align-items: stretch;
         gap: 8px;
-        border-bottom: 1px solid #f0f0f0;
 
         &:hover {
           background-color: #f6f6f6;
@@ -252,6 +250,7 @@
           width: 16px;
           opacity: 0.9;
           cursor: grab;
+          align-self: center;
         }
 
         .remove {
@@ -261,6 +260,7 @@
           padding: 4px;
           opacity: 0.9;
           justify-self: center;
+          align-self: center;
           border-radius: 4px;
           line-height: 0;
           img {
@@ -269,6 +269,100 @@
           &:hover {
             opacity: 1;
           }
+        }
+
+        .blockPreview {
+          display: flex;
+          border: 1px solid #c0c0c0;
+          border-bottom: none;
+          border-radius: 0;
+          overflow: hidden;
+          font-size: 0.9em;
+          user-select: none;
+        }
+
+        &:last-child .blockPreview {
+          border-bottom: 1px solid #c0c0c0;
+        }
+
+        &:first-child .blockPreview {
+          border-radius: 4px 4px 0 0;
+        }
+
+        &:last-child .blockPreview {
+          border-radius: 0 0 4px 4px;
+        }
+
+        .blockPreviewHeader {
+          background-color: #f0f0f0;
+          font-weight: 700;
+          color: #050020cf;
+          padding: 0;
+          border-right: 1px solid #c0c0c0;
+          display: flex;
+          align-items: stretch;
+          flex: 0 0 220px;
+          width: 220px;
+          box-sizing: border-box;
+
+          textarea.blockName {
+            flex: 1;
+            width: 100%;
+            min-height: 100%;
+            resize: none;
+            overflow: hidden;
+            background: none;
+            border: none;
+            font-weight: 700;
+            color: #050020cf;
+            font-size: inherit;
+            font-family: inherit;
+            line-height: inherit;
+            padding: 10px;
+            box-sizing: border-box;
+            cursor: text;
+            user-select: text;
+            min-width: 0;
+            &:focus {
+              outline: 2px solid #6b8cff;
+              outline-offset: -2px;
+              border-radius: 2px;
+            }
+          }
+        }
+
+        .blockPreviewHeader:not(:has(textarea)) {
+          padding: 10px;
+        }
+
+        .blockPreviewBody {
+          flex: 1;
+          min-width: 0;
+          padding: 10px;
+          color: #555;
+          font-size: 0.88em;
+          overflow: hidden;
+
+          p {
+            margin: 0;
+          }
+        }
+      }
+
+      .addBlockBtn {
+        width: 100%;
+        margin-top: 8px;
+        padding: 8px;
+        border: 2px dashed #c0c0c0;
+        border-radius: 6px;
+        background: none;
+        cursor: pointer;
+        color: #555;
+        font-size: 1em;
+        text-align: center;
+        &:hover {
+          border-color: #6b8cff;
+          color: #3355cc;
         }
       }
     }

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -174,11 +174,16 @@
 
   .closeModalIcon {
     cursor: pointer;
-    max-width: 20px;
+    background: none;
+    border: none;
     padding: 10px;
     position: absolute;
     top: 20px;
     right: 10px;
+    line-height: 0;
+    img {
+      width: 20px;
+    }
   }
 
   .container {
@@ -251,11 +256,16 @@
 
         .remove {
           cursor: pointer;
-          width: 14px;
+          background: none;
+          border: none;
           padding: 4px;
           opacity: 0.9;
           justify-self: center;
           border-radius: 4px;
+          line-height: 0;
+          img {
+            width: 14px;
+          }
           &:hover {
             opacity: 1;
           }
@@ -289,6 +299,7 @@
         }
         .restore {
           cursor: pointer;
+          user-select: none;
           display: flex;
           align-items: center;
           gap: 4px;

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -209,161 +209,157 @@
       margin-top: 4px;
     }
 
+    .moving {
+      background-color: #eef2ff !important;
+      box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+      z-index: 1000;
+      pointer-events: none;
+      transition: none !important;
+    }
+
+    .studyBlock {
+      font-size: 1.1em;
+      user-select: none;
+      padding: 0 6px;
+      cursor: grab;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+      grid-template-columns: 20px 1fr 30px;
+      display: grid;
+      align-items: stretch;
+      gap: 8px;
+
+      &:hover {
+        background-color: #f6f6f6;
+      }
+
+      .dragHandle {
+        width: 16px;
+        opacity: 0.9;
+        cursor: grab;
+        align-self: center;
+      }
+
+      .remove {
+        cursor: pointer;
+        background: none;
+        border: none;
+        padding: 4px;
+        opacity: 0.9;
+        justify-self: center;
+        align-self: center;
+        border-radius: 4px;
+        line-height: 0;
+        img {
+          width: 14px;
+        }
+        &:hover {
+          opacity: 1;
+        }
+      }
+
+      .blockPreview {
+        display: flex;
+        border: 1px solid #c0c0c0;
+        border-bottom: none;
+        border-radius: 0;
+        overflow: hidden;
+        font-size: 0.9em;
+        user-select: none;
+      }
+
+      &:first-child .blockPreview {
+        border-radius: 4px 4px 0 0;
+      }
+
+      &:last-child .blockPreview {
+        border-bottom: 1px solid #c0c0c0;
+        border-radius: 0 0 4px 4px;
+      }
+
+      .blockPreviewHeader {
+        background-color: #f0f0f0;
+        font-weight: 700;
+        color: #050020cf;
+        padding: 0;
+        border-right: 1px solid #c0c0c0;
+        display: flex;
+        align-items: stretch;
+        flex: 0 0 220px;
+        width: 220px;
+        box-sizing: border-box;
+
+        textarea.blockName {
+          flex: 1;
+          width: 100%;
+          min-height: 100%;
+          resize: none;
+          overflow: hidden;
+          background: none;
+          border: none;
+          font-weight: 700;
+          color: #050020cf;
+          font-size: inherit;
+          font-family: inherit;
+          line-height: inherit;
+          padding: 10px;
+          box-sizing: border-box;
+          cursor: text;
+          user-select: text;
+          min-width: 0;
+          &:focus {
+            outline: 2px solid #6b8cff;
+            outline-offset: -2px;
+            border-radius: 2px;
+          }
+        }
+      }
+
+      .blockPreviewHeader:not(:has(textarea)) {
+        padding: 10px;
+      }
+
+      .blockPreviewBody {
+        flex: 1;
+        min-width: 0;
+        padding: 10px;
+        color: #555;
+        font-size: 0.88em;
+        overflow: hidden;
+
+        p {
+          margin: 0;
+        }
+      }
+    }
+
+    .dropPlaceholder {
+      border-radius: 6px;
+      background: #e8eeff;
+      border: 2px dashed #b0c4ff;
+      box-sizing: border-box;
+      transition: height 0.15s ease;
+    }
+
     #studyBlockEditorContent {
       padding: 4px 0;
       position: relative;
       overflow: visible;
-      .dropPlaceholder {
-        border-radius: 6px;
-        background: #e8eeff;
-        border: 2px dashed #b0c4ff;
-        box-sizing: border-box;
-        transition: height 0.15s ease;
-      }
-      .moving {
-        background-color: #eef2ff !important;
-        box-shadow: 0 8px 20px rgba(0,0,0,0.15);
-        z-index: 10;
-        position: absolute;
-        width: 100%;
-        transition: none !important;
-      }
-      .swapping {
-        transition: transform 0.2s ease;
-      }
-      .studyBlock {
-        font-size: 1.1em;
-        user-select: none;
-        padding: 0 6px;
-        cursor: grab;
-        transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
-        grid-template-columns: 20px 1fr 30px;
-        display: grid;
-        align-items: stretch;
-        gap: 8px;
+    }
 
-        &:hover {
-          background-color: #f6f6f6;
-        }
-
-        .dragHandle {
-          width: 16px;
-          opacity: 0.9;
-          cursor: grab;
-          align-self: center;
-        }
-
-        .remove {
-          cursor: pointer;
-          background: none;
-          border: none;
-          padding: 4px;
-          opacity: 0.9;
-          justify-self: center;
-          align-self: center;
-          border-radius: 4px;
-          line-height: 0;
-          img {
-            width: 14px;
-          }
-          &:hover {
-            opacity: 1;
-          }
-        }
-
-        .blockPreview {
-          display: flex;
-          border: 1px solid #c0c0c0;
-          border-bottom: none;
-          border-radius: 0;
-          overflow: hidden;
-          font-size: 0.9em;
-          user-select: none;
-        }
-
-        &:last-child .blockPreview {
-          border-bottom: 1px solid #c0c0c0;
-        }
-
-        &:first-child .blockPreview {
-          border-radius: 4px 4px 0 0;
-        }
-
-        &:last-child .blockPreview {
-          border-radius: 0 0 4px 4px;
-        }
-
-        .blockPreviewHeader {
-          background-color: #f0f0f0;
-          font-weight: 700;
-          color: #050020cf;
-          padding: 0;
-          border-right: 1px solid #c0c0c0;
-          display: flex;
-          align-items: stretch;
-          flex: 0 0 220px;
-          width: 220px;
-          box-sizing: border-box;
-
-          textarea.blockName {
-            flex: 1;
-            width: 100%;
-            min-height: 100%;
-            resize: none;
-            overflow: hidden;
-            background: none;
-            border: none;
-            font-weight: 700;
-            color: #050020cf;
-            font-size: inherit;
-            font-family: inherit;
-            line-height: inherit;
-            padding: 10px;
-            box-sizing: border-box;
-            cursor: text;
-            user-select: text;
-            min-width: 0;
-            &:focus {
-              outline: 2px solid #6b8cff;
-              outline-offset: -2px;
-              border-radius: 2px;
-            }
-          }
-        }
-
-        .blockPreviewHeader:not(:has(textarea)) {
-          padding: 10px;
-        }
-
-        .blockPreviewBody {
-          flex: 1;
-          min-width: 0;
-          padding: 10px;
-          color: #555;
-          font-size: 0.88em;
-          overflow: hidden;
-
-          p {
-            margin: 0;
-          }
-        }
-      }
-
-      .addBlockBtn {
-        width: 100%;
-        margin-top: 8px;
-        padding: 8px;
-        border: 2px dashed #c0c0c0;
-        border-radius: 6px;
-        background: none;
-        cursor: pointer;
-        color: #555;
-        font-size: 1em;
-        text-align: center;
-        &:hover {
-          border-color: #6b8cff;
-          color: #3355cc;
-        }
+    .addBlockBtn {
+      width: 100%;
+      margin-top: 8px;
+      padding: 8px;
+      border: 2px dashed #c0c0c0;
+      border-radius: 6px;
+      background: none;
+      cursor: pointer;
+      color: #555;
+      font-size: 1em;
+      text-align: center;
+      &:hover {
+        border-color: #6b8cff;
+        color: #3355cc;
       }
     }
 
@@ -379,38 +375,27 @@
       }
 
       .studyBlock {
-        opacity: 0.5;
-        cursor: default;
-        display: grid;
-        grid-template-columns: 1fr auto;
-        align-items: center;
-        padding: 8px 10px;
-        border-radius: 6px;
-        font-size: 1.1em;
-        &:hover {
-          background-color: #f6f6f6;
-          opacity: 0.7;
+        .blockPreview {
+          border-color: #bbb;
+          background-color: #fafafa;
         }
-        .restore {
-          cursor: pointer;
-          user-select: none;
-          display: flex;
-          align-items: center;
-          gap: 4px;
-          opacity: 1;
-          font-size: 13px;
-          color: #444;
-          padding: 4px 10px;
-          border-radius: 4px;
-          border: 1px solid #ccc;
-          background: #fff;
-          img {
-            width: 18px;
+
+        .blockPreviewHeader {
+          background-color: #e8e8e8;
+          color: #999;
+
+          textarea.blockName {
+            color: #999;
+            text-decoration: line-through;
           }
-          &:hover {
-            background-color: #f0f0f0;
-            border-color: #aaa;
-          }
+        }
+
+        .blockPreviewBody {
+          color: #bbb;
+        }
+
+        .remove {
+          opacity: 0.45;
         }
       }
     }

--- a/backend/static/styles/utils/base.css
+++ b/backend/static/styles/utils/base.css
@@ -20,6 +20,7 @@ body {
   --blue-100: #0057d1;
   --blue-75: #4181dc;
   --blue-50: #9fc5ff;
+  --blue-35: #e0edff;
   --blue-25: #eef5ff;
   --indent1: rgba(102, 150, 217, 0.5);
   --indent2: rgba(78, 177, 104, 0.5);

--- a/backend/static/styles/utils/button.css
+++ b/backend/static/styles/utils/button.css
@@ -11,7 +11,7 @@ button {
   border-radius: 5px;
   padding: 5px 13px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
   transition: background-color .3s;
   &:disabled {
     cursor: not-allowed;
@@ -21,12 +21,22 @@ button {
 button.lightBlue {
   color: var(--blue-100);
   background-color: var(--blue-25);
-  border: 2px solid var(--blue-50);
+  border: 1px solid var(--blue-50);
   &:hover {
-    background-color: var(--blue-50);
+    background-color: var(--blue-35);
   }
   &:disabled {
-    border: 2px solid var(--red-50);
+    border: 1px solid var(--red-50);
+  }
+}
+
+button.ghostBlue {
+  color: var(--blue-100);
+  background-color: #fff;
+  border: 1px solid #ccc;
+  &:hover {
+    background-color: var(--blue-25);
+    border-color: var(--blue-50);
   }
 }
 
@@ -41,7 +51,7 @@ button.blue {
   }
   &:disabled {
     background-color: var(--blue-75);
-    border: 2px solid var(--red-50);
+    border: 1px solid var(--red-50);
   }
 }
 

--- a/backend/templates/studies.html
+++ b/backend/templates/studies.html
@@ -162,7 +162,7 @@
 
 <dialog id="newStudy">
   <h3>Create New Study</h3>
-  <img alt="Close Modal" src="{{base}}/static/img/x.svg" class="closeModalIcon" onclick="toggleModal('#newStudy')">
+  <button class="closeModalIcon" onclick="toggleModal('#newStudy')" aria-label="Close"><img src="{{base}}/static/img/x.svg" alt=""></button>
   <form hx-post="{{base}}/study">
     <label for="studyTitle">Title</label>
     <input type="text" required name="studyTitle" placeholder="New Title...">

--- a/backend/templates/study.html
+++ b/backend/templates/study.html
@@ -332,7 +332,7 @@
       <header>
         <h2>Edit Study Blocks</h2>
         <div class="subtitle">
-          Drag to reorder, ✕ to remove.
+          Drag to reorder, rename, or remove blocks.
         </div>
       </header>
       <div id="studyBlockEditorContent">

--- a/backend/templates/study.html
+++ b/backend/templates/study.html
@@ -328,7 +328,7 @@
 
   <dialog class="popup" id="studyBlockEditor">
     <div class="container">
-      <img alt="Close Modal" src="{{base}}/static/img/x.svg" class="closeModalIcon" onclick="toggleModal('#studyBlockEditor')">
+      <button class="closeModalIcon" onclick="toggleModal('#studyBlockEditor')" aria-label="Close"><img src="{{base}}/static/img/x.svg" alt=""></button>
       <header>
         <h2>Edit Study Blocks</h2>
         <div class="subtitle">

--- a/backend/templates/study.html
+++ b/backend/templates/study.html
@@ -328,13 +328,18 @@
 
   <dialog class="popup" id="studyBlockEditor">
     <div class="container">
+      <img alt="Close Modal" src="{{base}}/static/img/x.svg" class="closeModalIcon" onclick="toggleModal('#studyBlockEditor')">
       <header>
         <h2>Edit Study Blocks</h2>
-        <div style="color:gray">
-          Click and grad to move the study blocks around.
+        <div class="subtitle">
+          Drag to reorder, ✕ to remove.
         </div>
       </header>
       <div id="studyBlockEditorContent">
+      </div>
+      <div id="studyBlockEditorRemoved" style="display:none">
+        <div class="removedHeader">Removed</div>
+        <div id="studyBlockEditorRemovedList"></div>
       </div>
       <footer>
         <button class="red" id="studyBlockCancel">Cancel</button>

--- a/frontend/src/Editor/Editor.tsx
+++ b/frontend/src/Editor/Editor.tsx
@@ -83,6 +83,7 @@ class StudyBlocksView implements NodeView {
     editIcon.appendChild(editImg);
     editIcon.appendChild(document.createTextNode("Edit blocks"));
 
+    editIcon.addEventListener("mousedown", (e) => { e.preventDefault(); });
     editIcon.addEventListener("click", () => {
       let sectionNode : Node = null;
       let sectionPos = null;

--- a/frontend/src/Editor/Editor.tsx
+++ b/frontend/src/Editor/Editor.tsx
@@ -76,10 +76,14 @@ class StudyBlocksView implements NodeView {
     const table = document.createElement("table");
     table.className = "studyBlocks";
 
-    // Create and configure the Pencil icon
-    const editIcon = new Image();
-    editIcon.src = "/static/img/gray-pencil-in-circle.svg";
-    editIcon.className = "studyBlockEditPencil";
+    // Create and configure the Edit blocks button
+    const editIcon = document.createElement("button");
+    editIcon.className = "studyBlockEditPencil ghostBlue";
+    const editImg = new Image();
+    editImg.src = "/static/img/gray-pencil-in-circle.svg";
+    editImg.draggable = false;
+    editIcon.appendChild(editImg);
+    editIcon.appendChild(document.createTextNode("Edit blocks"));
 
     editIcon.addEventListener("click", () => {
       let sectionNode : Node = null;

--- a/frontend/src/Editor/Editor.tsx
+++ b/frontend/src/Editor/Editor.tsx
@@ -102,7 +102,7 @@ class StudyBlocksView implements NodeView {
         if(parent.type.name === "section" && node.type.name === "studyBlocks") {
           return true;
         } else if(parent.type.name === "section") {
-          return false
+          return false;
         }
         if(parent.type.name === "studyBlocks") {
           studyBlocks.push({node, pos});
@@ -119,6 +119,10 @@ class StudyBlocksView implements NodeView {
     // Set the table as the main content
     this.contentDOM = table;
     this.dom.appendChild(table);
+  }
+
+  stopEvent(e: Event): boolean {
+    return e.type === "mousedown" || e.type === "click";
   }
 }
 

--- a/frontend/src/Editor/Editor.tsx
+++ b/frontend/src/Editor/Editor.tsx
@@ -33,7 +33,6 @@ import { keymap } from "prosemirror-keymap";
 import { Slice, Node, Mark, Fragment } from "prosemirror-model";
 import { StepMap, Step, Transform } from "prosemirror-transform";
 import { baseKeymap } from "prosemirror-commands";
-// import AddScriptureIcon from "../Assets/add-scripture.svg";
 import {
   questionHighlightPlugin,
   highlighQuestion,
@@ -42,7 +41,6 @@ import {
 import { otherCursorPlugin, setSelection } from "./OtherCursorPlugin";
 import {getRandomStr} from "../Util";
 
-// import CloseXIcon from "../Assets/x.svg";
 import { v4 as uuidv4 } from "uuid";
 
 // var blockMap : Dictionary<BlockMapItem> = {};

--- a/frontend/src/Editor/Editor.tsx
+++ b/frontend/src/Editor/Editor.tsx
@@ -199,6 +199,8 @@ class QuestionsView implements NodeView {
       noQuestionsText.className = "noQuestionsText";
       noQuestionsText.innerHTML = `<em>Insert a question by selecting some text and clicking the "Add Question" button</em> <img src="${window.base}/static/img/question-icon.svg" alt="Add Question Icon"> <em>in the toolbar above</em>`;
 
+      noQuestionsText.setAttribute("contenteditable", "false");
+      noQuestionsText.addEventListener("mousedown", (e) => { e.preventDefault(); });
       noQuestionsText.onclick = () => {
         // Logic to move the cursor to the previous position
         const transaction = view.state.tr.setSelection(
@@ -318,6 +320,7 @@ export class QuestionView implements NodeView {
 
     if (view.editable) {
       const addAnswer = document.createElement("button");
+      addAnswer.addEventListener("mousedown", (e) => { e.preventDefault(); });
       addAnswer.onclick = (e) => {
         e.preventDefault();
         const qnode = newQuestionAnswerNode();
@@ -760,7 +763,7 @@ let questionMarkPlugin = (
             Decoration.widget(loc, questionMarkWidget(qId, questionMap, setCurrentEditor), {
               key: "qmark" + qId,
               stopEvent: (e: Event) => {
-                return e.type === "click";
+                return e.type === "mousedown" || e.type === "click";
               },
               side: -1,
             })
@@ -1121,6 +1124,7 @@ const mkPlaceholderElement = (pos) => (view: EditorView) => {
     <em>above to add your verses here</em>
   `;
 
+  placeholderElement.addEventListener("mousedown", (e) => { e.preventDefault(); });
   placeholderElement.onclick = () => {
     // Logic to move the cursor to the previous position
     const transaction = view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(pos)));

--- a/frontend/src/Editor/editorUtils.tsx
+++ b/frontend/src/Editor/editorUtils.tsx
@@ -226,6 +226,27 @@ export const addGeneralStudyBlock = (state: EditorState, dispatch?: (tr: Transac
   }
 };
 
+// Create a brand-new generalStudyBlock node with a given name and empty body
+export const createGeneralStudyBlockNode = (name: string): Node => {
+  const headerText = name ? [textSchema.text(name)] : [];
+  const sbHeader = textSchema.nodes.generalStudyBlockHeader.createChecked(null, headerText);
+  const bodyp = textSchema.nodes.paragraph.createChecked(null, []);
+  const sbBody = textSchema.nodes.generalStudyBlockBody.create(null, bodyp);
+  return textSchema.nodes.generalStudyBlock.createChecked({ id: uuidv4() }, [sbHeader, sbBody]);
+};
+
+// Return a copy of a generalStudyBlock node with a new header name
+export const withRenamedHeader = (node: Node, newName: string): Node => {
+  const headerText = newName ? [textSchema.text(newName)] : [];
+  const newHeader = textSchema.nodes.generalStudyBlockHeader.createChecked(null, headerText);
+  let body: Node | null = null;
+  node.forEach(child => {
+    if (child.type.name === "generalStudyBlockBody") body = child;
+  });
+  const children = body ? [newHeader, body] : [newHeader];
+  return textSchema.nodes.generalStudyBlock.createChecked(node.attrs, children);
+};
+
 const nodeIsChunk = (node: Node) => {
   if (node.type.name === "section") return true;
   if (node.type.name === "bibleText") return true;

--- a/frontend/src/GroupStudy.ts
+++ b/frontend/src/GroupStudy.ts
@@ -31,7 +31,6 @@ export function init(ws : WS.MyWebsocket) {
 
     ws.addEventListener("DocListenStart", (ev : WS.DocListenStartEvent) => {
       const doc = ev.document;
-      console.log(doc);
       if(editor) {
         editor.removeEditor();
       }

--- a/frontend/src/GroupStudy.ts
+++ b/frontend/src/GroupStudy.ts
@@ -31,6 +31,7 @@ export function init(ws : WS.MyWebsocket) {
 
     ws.addEventListener("DocListenStart", (ev : WS.DocListenStartEvent) => {
       const doc = ev.document;
+      console.log(doc);
       if(editor) {
         editor.removeEditor();
       }

--- a/frontend/src/SidebarSections.ts
+++ b/frontend/src/SidebarSections.ts
@@ -60,7 +60,7 @@ function createSectionHeader(editor : Editor.P215Editor, index : number) {
   section.appendChild(sectionText);
 
   const remove = document.createElement("div");
-  remove.innerHTML = "х";
+  remove.innerText = "х";
   // const img = document.createElement("img");
   // img.src = "/static/img/x.svg";
   remove.className = "remove";

--- a/frontend/src/SidebarSections.ts
+++ b/frontend/src/SidebarSections.ts
@@ -60,9 +60,7 @@ function createSectionHeader(editor : Editor.P215Editor, index : number) {
   section.appendChild(sectionText);
 
   const remove = document.createElement("div");
-  remove.innerText = "х";
-  // const img = document.createElement("img");
-  // img.src = "/static/img/x.svg";
+  remove.innerText = "x";
   remove.className = "remove";
   remove.addEventListener("click", (e) => {
     e.stopPropagation();

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -1,5 +1,7 @@
 import * as Editor from "./Editor/Editor"
 import * as EditorUtil from "./Editor/editorUtils"
+import { Node, DOMSerializer } from "prosemirror-model"
+import { textSchema } from "./Editor/textSchema"
 
 document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
   const editor = ev.editor;
@@ -13,6 +15,248 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
   const removedSection = document.getElementById("studyBlockEditorRemoved");
   const removedList = document.getElementById("studyBlockEditorRemovedList");
 
+  // Get or create the "Add block" button below the content area
+  let addBlockBtn = document.getElementById("studyBlockAddBtn") as HTMLButtonElement | null;
+  if (!addBlockBtn) {
+    addBlockBtn = document.createElement("button");
+    addBlockBtn.id = "studyBlockAddBtn";
+    addBlockBtn.className = "addBlockBtn";
+    addBlockBtn.textContent = "+ Add block";
+    container.parentElement.insertBefore(addBlockBtn, container.nextSibling);
+  }
+
+  const bodySerializer = DOMSerializer.fromSchema(textSchema);
+
+  function populateBodyPreview(node: Node, el: HTMLElement): void {
+    node.forEach(child => {
+      if (child.type.name === "generalStudyBlockBody") {
+        // Only render the first 2 paragraphs so no third line ever enters the DOM
+        let count = 0;
+        child.forEach(para => {
+          if (count >= 2) return;
+          const serialized = bodySerializer.serializeNode(para);
+          el.appendChild(serialized);
+          count++;
+        });
+      }
+    });
+  }
+
+  function makeBlockItem(node: Node | null, index: number | null, isNew: boolean): HTMLElement {
+    const div = document.createElement("div");
+    div.className = "studyBlock";
+
+    const handle = document.createElement("img");
+    handle.src = "/static/img/drag-handle.svg";
+    handle.className = "dragHandle";
+    handle.draggable = false;
+    div.appendChild(handle);
+
+    let startMouseY = 0;
+    let initialTop = 0;
+    let swapping = false;
+    let placeholder: HTMLElement = null;
+
+    div.addEventListener("mousedown", (e: MouseEvent) => {
+      if (e.button === 0) {
+        // Don't start drag if clicking on the input
+        if ((e.target as HTMLElement).tagName === "INPUT") return;
+        e.preventDefault();
+        startMouseY = e.clientY;
+        document.addEventListener("mousemove", mousemove);
+        document.addEventListener("mouseup", mouseup);
+      }
+    });
+
+    function mouseup() {
+      document.removeEventListener("mouseup", mouseup);
+      document.removeEventListener("mousemove", mousemove);
+      if (placeholder) {
+        placeholder.remove();
+        placeholder = null;
+      }
+      div.classList.remove("moving");
+      div.style.top = "";
+    }
+
+    function mousemove(e: MouseEvent) {
+      if (!div.classList.contains("moving")) {
+        if (Math.abs(e.clientY - startMouseY) < 3) return;
+        const rect = div.getBoundingClientRect();
+        const containerRect = div.parentElement.getBoundingClientRect();
+        initialTop = rect.top - containerRect.top;
+        div.classList.add("moving");
+        placeholder = document.createElement("div");
+        placeholder.className = "dropPlaceholder";
+        placeholder.style.height = rect.height + "px";
+        div.parentElement.insertBefore(placeholder, div);
+        div.style.top = initialTop + "px";
+      }
+
+      const dy = e.clientY - startMouseY;
+      div.style.top = (initialTop + dy) + "px";
+
+      if (swapping) return;
+
+      const next = div.nextElementSibling as HTMLElement;
+      const previous = placeholder ? placeholder.previousElementSibling as HTMLElement : null;
+
+      if (next && !next.classList.contains("dropPlaceholder")) {
+        const nextRect = next.getBoundingClientRect();
+        const nextMid = nextRect.top + nextRect.height * 0.2;
+        if (e.clientY > nextMid) {
+          doSwap(next, "down");
+          return;
+        }
+      }
+      if (previous && !previous.classList.contains("dropPlaceholder")) {
+        const prevRect = previous.getBoundingClientRect();
+        const prevMid = prevRect.top + prevRect.height * 0.8;
+        if (e.clientY < prevMid) {
+          doSwap(previous, "up");
+        }
+      }
+    }
+
+    function doSwap(sibling: HTMLElement, direction: "up" | "down") {
+      swapping = true;
+      if (direction === "down") {
+        div.parentElement.insertBefore(sibling, placeholder);
+      } else {
+        div.parentElement.insertBefore(placeholder, sibling);
+        div.parentElement.insertBefore(div, sibling);
+      }
+      const placeholderHeight = placeholder.getBoundingClientRect().height;
+      const fromOffset = direction === "down" ? placeholderHeight : -placeholderHeight;
+      sibling.classList.add("swapping");
+      sibling.style.transform = `translateY(${fromOffset}px)`;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          sibling.style.transform = "";
+          sibling.addEventListener("transitionend", () => {
+            sibling.classList.remove("swapping");
+            swapping = false;
+          }, { once: true });
+          setTimeout(() => { swapping = false; }, 250);
+        });
+      });
+    }
+
+    if (isNew) {
+      div.setAttribute("data-new", "true");
+    } else {
+      div.setAttribute("originalIndex", index + "");
+    }
+
+    // Build preview row
+    const preview = document.createElement("div");
+    preview.className = "blockPreview";
+
+    const headerCell = document.createElement("div");
+    headerCell.className = "blockPreviewHeader";
+
+    const isQuestions = node && node.type.name === "questions";
+
+    if (isQuestions) {
+      headerCell.textContent = "Questions";
+    } else {
+      const nameInput = document.createElement("textarea");
+      nameInput.rows = 1;
+      // Prevent Enter from inserting newlines — block names are single-line
+      nameInput.addEventListener("keydown", (e: KeyboardEvent) => {
+        if (e.key === "Enter") e.preventDefault();
+      });
+      // Grow the textarea vertically as text wraps
+      const resizeTextarea = () => {
+        nameInput.style.height = "auto";
+        nameInput.style.height = nameInput.scrollHeight + "px";
+      };
+      nameInput.addEventListener("input", resizeTextarea);
+      // Resize on initial load once the element is in the DOM
+      requestAnimationFrame(resizeTextarea);
+      // Clicking anywhere in the header cell focuses the textarea
+      headerCell.addEventListener("click", () => nameInput.focus());
+      nameInput.className = "blockName";
+      if (node) {
+        let name = "";
+        node.forEach(child => {
+          if (child.type.name === "generalStudyBlockHeader") {
+            name = child.textContent;
+          }
+        });
+        nameInput.value = name;
+        nameInput.placeholder = "Untitled";
+      } else {
+        nameInput.value = "";
+        nameInput.placeholder = "Block name";
+      }
+      headerCell.appendChild(nameInput);
+      // Focus input for new blocks
+      if (isNew) {
+        requestAnimationFrame(() => nameInput.focus());
+      }
+    }
+
+    const bodyCell = document.createElement("div");
+    bodyCell.className = "blockPreviewBody";
+    if (!isQuestions && node) {
+      populateBodyPreview(node, bodyCell);
+    }
+
+    preview.appendChild(headerCell);
+    preview.appendChild(bodyCell);
+    div.appendChild(preview);
+
+    if (!isQuestions) {
+      const remove = document.createElement("button");
+      remove.className = "remove";
+      const removeImg = document.createElement("img");
+      removeImg.src = "/static/img/x.svg";
+      removeImg.draggable = false;
+      removeImg.alt = "";
+      remove.appendChild(removeImg);
+      remove.addEventListener("click", (e) => {
+        e.stopPropagation();
+        // For new blocks, just remove entirely — no restore
+        if (isNew) {
+          container.removeChild(div);
+          return;
+        }
+        container.removeChild(div);
+        const name = (headerCell.querySelector("input") as HTMLInputElement)?.value
+          || (node ? node.textContent : "");
+        const removedDiv = document.createElement("div");
+        removedDiv.className = "studyBlock";
+        const removedName = document.createElement("div");
+        removedName.innerText = name || "Untitled";
+        removedName.style.textDecoration = "line-through";
+        removedDiv.appendChild(removedName);
+        const restoreBtn = document.createElement("button");
+        restoreBtn.className = "restore";
+        const restoreIcon = document.createElement("img");
+        restoreIcon.src = "/static/img/undo-icon.svg";
+        restoreIcon.draggable = false;
+        restoreBtn.appendChild(restoreIcon);
+        const restoreText = document.createElement("span");
+        restoreText.innerText = "Restore";
+        restoreBtn.appendChild(restoreText);
+        restoreBtn.addEventListener("click", () => {
+          removedList.removeChild(removedDiv);
+          if (removedList.children.length === 0) {
+            removedSection.style.display = "none";
+          }
+          container.appendChild(div);
+        });
+        removedDiv.appendChild(restoreBtn);
+        removedList.appendChild(removedDiv);
+        removedSection.style.display = "block";
+      });
+      div.appendChild(remove);
+    }
+
+    return div;
+  }
+
   editor.addEventListener("studyblocks-edit", (ev : Editor.EditorStudyBlocksEdit) => {
     container.innerHTML = "";
     removedList.innerHTML = "";
@@ -21,184 +265,40 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
     const studyBlocks = ev.studyBlocks;
     currentStudyBlock = ev;
 
-    studyBlocks.forEach( ({node}, index) => {
-      const div = document.createElement("div");
-      div.className = "studyBlock";
-
-      const handle = document.createElement("img");
-      handle.src = "/static/img/drag-handle.svg";
-      handle.className = "dragHandle";
-      handle.draggable = false;
-      div.appendChild(handle);
-
-      let startMouseY = 0;
-      let initialTop = 0;
-      let swapping = false;
-
-      let placeholder: HTMLElement = null;
-
-      div.addEventListener("mousedown", (e: MouseEvent) => {
-        if(e.button === 0) {
-          e.preventDefault();
-          startMouseY = e.clientY;
-          document.addEventListener("mousemove", mousemove);
-          document.addEventListener("mouseup", mouseup);
-        }
-      });
-
-      function mouseup () {
-        document.removeEventListener("mouseup", mouseup);
-        document.removeEventListener("mousemove", mousemove);
-
-        if (placeholder) {
-          placeholder.remove();
-          placeholder = null;
-        }
-        div.classList.remove("moving");
-        div.style.top = "";
-      };
-
-      function mousemove (e : MouseEvent) {
-        if (!div.classList.contains("moving")) {
-          if (Math.abs(e.clientY - startMouseY) < 3) return;
-          const rect = div.getBoundingClientRect();
-          const containerRect = div.parentElement.getBoundingClientRect();
-          initialTop = rect.top - containerRect.top;
-          div.classList.add("moving");
-          placeholder = document.createElement("div");
-          placeholder.className = "dropPlaceholder";
-          placeholder.style.height = rect.height + "px";
-          div.parentElement.insertBefore(placeholder, div);
-          div.style.top = initialTop + "px";
-        }
-
-        const dy = e.clientY - startMouseY;
-        div.style.top = (initialTop + dy) + "px";
-
-        if (swapping) return;
-
-        // Use the cursor position for hit testing
-        const next = div.nextElementSibling as HTMLElement;
-        const previous = placeholder ? placeholder.previousElementSibling as HTMLElement : null;
-
-        if (next && !next.classList.contains("dropPlaceholder")) {
-          const nextRect = next.getBoundingClientRect();
-          const nextMid = nextRect.top + nextRect.height * 0.2;
-          if (e.clientY > nextMid) {
-            doSwap(next, "down");
-            return;
-          }
-        }
-        if (previous && !previous.classList.contains("dropPlaceholder")) {
-          const prevRect = previous.getBoundingClientRect();
-          const prevMid = prevRect.top + prevRect.height * 0.8;
-          if (e.clientY < prevMid) {
-            doSwap(previous, "up");
-          }
-        }
-      };
-
-      function doSwap(sibling: HTMLElement, direction: "up" | "down") {
-        swapping = true;
-
-        // Move the placeholder (div stays absolute, unaffected by DOM order)
-        if (direction === "down") {
-          div.parentElement.insertBefore(sibling, placeholder);
-        } else {
-          div.parentElement.insertBefore(placeholder, sibling);
-          div.parentElement.insertBefore(div, sibling);
-        }
-
-        // Animate the displaced sibling from its old position
-        const placeholderHeight = placeholder.getBoundingClientRect().height;
-        const fromOffset = direction === "down" ? placeholderHeight : -placeholderHeight;
-        sibling.classList.add("swapping");
-        sibling.style.transform = `translateY(${fromOffset}px)`;
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            sibling.style.transform = "";
-            sibling.addEventListener("transitionend", () => {
-              sibling.classList.remove("swapping");
-              swapping = false;
-            }, { once: true });
-            // Fallback in case transitionend doesn't fire
-            setTimeout(() => { swapping = false; }, 250);
-          });
-        });
-      }
-
-      div.setAttribute("originalIndex", index + "");
-
-      let name = "";
-      if (node.type.name === "questions") {
-        name = "Questions";
-      } else {
-        node.descendants( (node) => {
-          if (node.type.name === "generalStudyBlockHeader") {
-            name = node.child(0).text;
-          }
-          return false;
-        })
-      }
-      const div2 = document.createElement("div");
-      div2.innerText = name;
-      div.appendChild(div2);
-
-      if (node.type.name !== "questions") {
-        const remove = document.createElement("button");
-        remove.className = "remove";
-        const removeImg = document.createElement("img");
-        removeImg.src = "/static/img/x.svg";
-        removeImg.draggable = false;
-        removeImg.alt = "";
-        remove.appendChild(removeImg);
-        remove.addEventListener("click", (e) => {
-          e.stopPropagation();
-          container.removeChild(div);
-          const removedDiv = document.createElement("div");
-          removedDiv.className = "studyBlock";
-          const removedName = document.createElement("div");
-          removedName.innerText = name;
-          removedName.style.textDecoration = "line-through";
-          removedDiv.appendChild(removedName);
-          const restoreBtn = document.createElement("button");
-          restoreBtn.className = "restore";
-          const restoreIcon = document.createElement("img");
-          restoreIcon.src = "/static/img/undo-icon.svg";
-          restoreIcon.draggable = false;
-          restoreBtn.appendChild(restoreIcon);
-          const restoreText = document.createElement("span");
-          restoreText.innerText = "Restore";
-          restoreBtn.appendChild(restoreText);
-          restoreBtn.addEventListener("click", () => {
-            removedList.removeChild(removedDiv);
-            if (removedList.children.length === 0) {
-              removedSection.style.display = "none";
-            }
-            container.appendChild(div);
-          });
-          removedDiv.appendChild(restoreBtn);
-          removedList.appendChild(removedDiv);
-          removedSection.style.display = "block";
-        });
-        div.appendChild(remove);
-      }
-
-      container.appendChild(div);
+    studyBlocks.forEach(({node}, index) => {
+      container.appendChild(makeBlockItem(node, index, false));
     });
+  });
+
+  addBlockBtn.addEventListener("click", () => {
+    if (currentStudyBlock === null) return;
+    container.appendChild(makeBlockItem(null, null, true));
   });
 
   document.getElementById("studyBlockUpdate").addEventListener("click", () => {
     if (currentStudyBlock === null) return;
-    let newPositions = [];
+    const newNodes: Node[] = [];
     const children = container.children;
     for (let i = 0; i < children.length; i++) {
-      const originalIndex = Number(children[i].getAttribute("originalIndex"));
-      newPositions.push(currentStudyBlock.studyBlocks[originalIndex].node);
+      const child = children[i] as HTMLElement;
+      if (child.getAttribute("data-new") === "true") {
+        const input = child.querySelector("textarea.blockName") as HTMLTextAreaElement;
+        const name = (input?.value.trim()) || "Untitled";
+        newNodes.push(EditorUtil.createGeneralStudyBlockNode(name));
+      } else {
+        const originalIndex = Number(child.getAttribute("originalIndex"));
+        let node = currentStudyBlock.studyBlocks[originalIndex].node;
+        if (node.type.name !== "questions") {
+          const input = child.querySelector("textarea.blockName") as HTMLTextAreaElement;
+          const newName = (input?.value.trim()) || "Untitled";
+          node = EditorUtil.withRenamedHeader(node, newName);
+        }
+        newNodes.push(node);
+      }
     }
     editor.applyDispatch(EditorUtil.reorderStudyBlock(
       currentStudyBlock.studyBlockPos,
-      newPositions
+      newNodes
     ));
     window.toggleModal("#studyBlockEditor");
   });

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -199,12 +199,10 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
   document.getElementById("studyBlockUpdate").addEventListener("click", () => {
     if (currentStudyBlock === null) return;
     let newPositions = [];
-    const children = container.children
+    const children = container.children;
     for (let i = 0; i < children.length; i++) {
-      const child = children[i];
-      const currentIndex = Number(child.getAttribute("currentIndex"));
-      const originalIndex = Number(child.getAttribute("originalIndex"));
-      newPositions[currentIndex] = currentStudyBlock.studyBlocks[originalIndex].node;
+      const originalIndex = Number(children[i].getAttribute("originalIndex"));
+      newPositions.push(currentStudyBlock.studyBlocks[originalIndex].node);
     }
     editor.applyDispatch(EditorUtil.reorderStudyBlock(
       currentStudyBlock.studyBlockPos,

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -100,16 +100,6 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
 
       function doSwap(sibling: HTMLElement, direction: "up" | "down") {
         swapping = true;
-        // Update indices
-        let sIndex = Number(sibling.getAttribute("currentIndex"));
-        let dIndex = Number(div.getAttribute("currentIndex"));
-        if (direction === "down") {
-          sIndex--; dIndex++;
-        } else {
-          sIndex++; dIndex--;
-        }
-        sibling.setAttribute("currentIndex", sIndex + "");
-        div.setAttribute("currentIndex", dIndex + "");
 
         // Move the placeholder (div stays absolute, unaffected by DOM order)
         if (direction === "down") {
@@ -138,7 +128,6 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
       }
 
       div.setAttribute("originalIndex", index + "");
-      div.setAttribute("currentIndex", index + "");
 
       let name = "";
       if (node.type.name === "questions") {
@@ -156,10 +145,13 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
       div.appendChild(div2);
 
       if (node.type.name !== "questions") {
-        const remove = document.createElement("img");
-        remove.src = "/static/img/x.svg";
+        const remove = document.createElement("button");
         remove.className = "remove";
-        remove.draggable = false;
+        const removeImg = document.createElement("img");
+        removeImg.src = "/static/img/x.svg";
+        removeImg.draggable = false;
+        removeImg.alt = "";
+        remove.appendChild(removeImg);
         remove.addEventListener("click", (e) => {
           e.stopPropagation();
           container.removeChild(div);
@@ -169,7 +161,7 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
           removedName.innerText = name;
           removedName.style.textDecoration = "line-through";
           removedDiv.appendChild(removedName);
-          const restoreBtn = document.createElement("div");
+          const restoreBtn = document.createElement("button");
           restoreBtn.className = "restore";
           const restoreIcon = document.createElement("img");
           restoreIcon.src = "/static/img/undo-icon.svg";

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -34,15 +34,15 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
 
       let startMouseY = 0;
       let startMouseX = 0;
-      let grabOffsetY = 0; // where on the element the user grabbed
-      let initialTop = 0;  // element's top relative to container at drag start
+      let initialTop = 0;
       let initialLeft = 0;
       let swapping = false;
 
       let placeholder: HTMLElement = null;
 
       div.addEventListener("mousedown", (e: MouseEvent) => {
-        if(e.button == 0) {
+        if(e.button === 0) {
+          e.preventDefault();
           startMouseY = e.clientY;
           startMouseX = e.clientX;
           document.addEventListener("mousemove", mousemove);
@@ -111,7 +111,6 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
           const containerRect = div.parentElement.getBoundingClientRect();
           initialTop = rect.top - containerRect.top;
           initialLeft = rect.left - containerRect.left;
-          grabOffsetY = startMouseY - rect.top;
           div.classList.add("moving");
           placeholder = document.createElement("div");
           placeholder.className = "dropPlaceholder";
@@ -153,8 +152,6 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
 
       function doSwap(sibling: HTMLElement, direction: "up" | "down") {
         swapping = true;
-        const siblingHeight = sibling.getBoundingClientRect().height;
-
         // Update indices
         let sIndex = Number(sibling.getAttribute("currentIndex"));
         let dIndex = Number(div.getAttribute("currentIndex"));
@@ -255,19 +252,18 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
   });
 
   document.getElementById("studyBlockUpdate").addEventListener("click", () => {
-    const container = document.getElementById("studyBlockEditorContent");
     if (currentStudyBlock === null) return;
-    let newPosistions = [];
+    let newPositions = [];
     const children = container.children
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
       const currentIndex = Number(child.getAttribute("currentIndex"));
       const originalIndex = Number(child.getAttribute("originalIndex"));
-      newPosistions[currentIndex] = currentStudyBlock.studyBlocks[originalIndex].node;
+      newPositions[currentIndex] = currentStudyBlock.studyBlocks[originalIndex].node;
     }
     editor.applyDispatch(EditorUtil.reorderStudyBlock(
       currentStudyBlock.studyBlockPos,
-      newPosistions
+      newPositions
     ));
     window.toggleModal("#studyBlockEditor");
   });

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -32,9 +32,7 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
       div.appendChild(handle);
 
       let startMouseY = 0;
-      let startMouseX = 0;
       let initialTop = 0;
-      let initialLeft = 0;
       let swapping = false;
 
       let placeholder: HTMLElement = null;
@@ -43,7 +41,6 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
         if(e.button === 0) {
           e.preventDefault();
           startMouseY = e.clientY;
-          startMouseX = e.clientX;
           document.addEventListener("mousemove", mousemove);
           document.addEventListener("mouseup", mouseup);
         }
@@ -54,51 +51,11 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
         document.removeEventListener("mousemove", mousemove);
 
         if (placeholder) {
-          const placeholderRect = placeholder.getBoundingClientRect();
-          const containerRect = div.parentElement.getBoundingClientRect();
-          const targetTop = placeholderRect.top - containerRect.top;
-          const targetLeft = placeholderRect.left - containerRect.left;
-
-          div.style.transition = "top 0.2s ease, left 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease";
-          div.style.top = targetTop + "px";
-          div.style.left = targetLeft + "px";
-          div.style.transform = "";
-
-          div.addEventListener("transitionend", function settle() {
-            div.removeEventListener("transitionend", settle);
-            div.style.top = "";
-            div.style.left = "";
-            if (placeholder) {
-              placeholder.remove();
-              placeholder = null;
-            }
-            // Fade out the blue background slowly
-            div.style.transition = "background-color 0.5s ease, box-shadow 0.3s ease";
-            div.classList.remove("moving");
-            div.addEventListener("transitionend", function fadeout() {
-              div.removeEventListener("transitionend", fadeout);
-              div.style.transition = "";
-            }, { once: true });
-          }, { once: true });
-
-          // Fallback in case transitionend doesn't fire
-          setTimeout(() => {
-            div.style.top = "";
-            div.style.left = "";
-            div.style.transition = "background-color 0.5s ease, box-shadow 0.3s ease";
-            div.classList.remove("moving");
-            if (placeholder) {
-              placeholder.remove();
-              placeholder = null;
-            }
-            setTimeout(() => { div.style.transition = ""; }, 600);
-          }, 300);
-        } else {
-          div.classList.remove("moving");
-          div.style.transform = "";
-          div.style.top = "";
-          div.style.left = "";
+          placeholder.remove();
+          placeholder = null;
         }
+        div.classList.remove("moving");
+        div.style.top = "";
       };
 
       function mousemove (e : MouseEvent) {
@@ -107,21 +64,16 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
           const rect = div.getBoundingClientRect();
           const containerRect = div.parentElement.getBoundingClientRect();
           initialTop = rect.top - containerRect.top;
-          initialLeft = rect.left - containerRect.left;
           div.classList.add("moving");
           placeholder = document.createElement("div");
           placeholder.className = "dropPlaceholder";
           placeholder.style.height = rect.height + "px";
           div.parentElement.insertBefore(placeholder, div);
           div.style.top = initialTop + "px";
-          div.style.left = initialLeft + "px";
         }
 
         const dy = e.clientY - startMouseY;
-        const dx = e.clientX - startMouseX;
         div.style.top = (initialTop + dy) + "px";
-        div.style.left = (initialLeft + dx) + "px";
-        div.style.transform = `scale(0.96) rotate(1.5deg)`;
 
         if (swapping) return;
 

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -1,4 +1,3 @@
-import { Node } from "prosemirror-model";
 import * as Editor from "./Editor/Editor"
 import * as EditorUtil from "./Editor/editorUtils"
 
@@ -50,13 +49,11 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
         }
       });
 
-
       function mouseup () {
         document.removeEventListener("mouseup", mouseup);
         document.removeEventListener("mousemove", mousemove);
 
         if (placeholder) {
-          // Animate back to placeholder position
           const placeholderRect = placeholder.getBoundingClientRect();
           const containerRect = div.parentElement.getBoundingClientRect();
           const targetTop = placeholderRect.top - containerRect.top;
@@ -120,7 +117,6 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
           div.style.left = initialLeft + "px";
         }
 
-        // Position: initial position + how far the mouse moved
         const dy = e.clientY - startMouseY;
         const dx = e.clientX - startMouseX;
         div.style.top = (initialTop + dy) + "px";
@@ -189,17 +185,14 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
         });
       }
 
-
-
-
       div.setAttribute("originalIndex", index + "");
       div.setAttribute("currentIndex", index + "");
 
       let name = "";
-      if (node.type.name == "questions") {
+      if (node.type.name === "questions") {
         name = "Questions";
       } else {
-        node.descendants( (node: Node) => {
+        node.descendants( (node) => {
           if (node.type.name === "generalStudyBlockHeader") {
             name = node.child(0).text;
           }
@@ -210,14 +203,14 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
       div2.innerText = name;
       div.appendChild(div2);
 
-      if (node.type.name != "questions") {
+      if (node.type.name !== "questions") {
         const remove = document.createElement("img");
         remove.src = "/static/img/x.svg";
         remove.className = "remove";
         remove.draggable = false;
         remove.addEventListener("click", (e) => {
+          e.stopPropagation();
           container.removeChild(div);
-          // Create a removed entry
           const removedDiv = document.createElement("div");
           removedDiv.className = "studyBlock";
           const removedName = document.createElement("div");
@@ -268,5 +261,3 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
     window.toggleModal("#studyBlockEditor");
   });
 });
-
-

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -11,8 +11,13 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
     window.toggleModal("#studyBlockEditor");
   });
 
+  const removedSection = document.getElementById("studyBlockEditorRemoved");
+  const removedList = document.getElementById("studyBlockEditorRemovedList");
+
   editor.addEventListener("studyblocks-edit", (ev : Editor.EditorStudyBlocksEdit) => {
     container.innerHTML = "";
+    removedList.innerHTML = "";
+    removedSection.style.display = "none";
     window.toggleModal("#studyBlockEditor");
     const studyBlocks = ev.studyBlocks;
     currentStudyBlock = ev;
@@ -21,8 +26,25 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
       const div = document.createElement("div");
       div.className = "studyBlock";
 
+      const handle = document.createElement("img");
+      handle.src = "/static/img/drag-handle.svg";
+      handle.className = "dragHandle";
+      handle.draggable = false;
+      div.appendChild(handle);
+
+      let startMouseY = 0;
+      let startMouseX = 0;
+      let grabOffsetY = 0; // where on the element the user grabbed
+      let initialTop = 0;  // element's top relative to container at drag start
+      let initialLeft = 0;
+      let swapping = false;
+
+      let placeholder: HTMLElement = null;
+
       div.addEventListener("mousedown", (e: MouseEvent) => {
         if(e.button == 0) {
+          startMouseY = e.clientY;
+          startMouseX = e.clientX;
           document.addEventListener("mousemove", mousemove);
           document.addEventListener("mouseup", mouseup);
         }
@@ -32,46 +54,142 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
       function mouseup () {
         document.removeEventListener("mouseup", mouseup);
         document.removeEventListener("mousemove", mousemove);
-        div.classList.remove("moving");
-        let currentIndex = Number(div.getAttribute("currentIndex"));
+
+        if (placeholder) {
+          // Animate back to placeholder position
+          const placeholderRect = placeholder.getBoundingClientRect();
+          const containerRect = div.parentElement.getBoundingClientRect();
+          const targetTop = placeholderRect.top - containerRect.top;
+          const targetLeft = placeholderRect.left - containerRect.left;
+
+          div.style.transition = "top 0.2s ease, left 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease";
+          div.style.top = targetTop + "px";
+          div.style.left = targetLeft + "px";
+          div.style.transform = "";
+
+          div.addEventListener("transitionend", function settle() {
+            div.removeEventListener("transitionend", settle);
+            div.style.top = "";
+            div.style.left = "";
+            if (placeholder) {
+              placeholder.remove();
+              placeholder = null;
+            }
+            // Fade out the blue background slowly
+            div.style.transition = "background-color 0.5s ease, box-shadow 0.3s ease";
+            div.classList.remove("moving");
+            div.addEventListener("transitionend", function fadeout() {
+              div.removeEventListener("transitionend", fadeout);
+              div.style.transition = "";
+            }, { once: true });
+          }, { once: true });
+
+          // Fallback in case transitionend doesn't fire
+          setTimeout(() => {
+            div.style.top = "";
+            div.style.left = "";
+            div.style.transition = "background-color 0.5s ease, box-shadow 0.3s ease";
+            div.classList.remove("moving");
+            if (placeholder) {
+              placeholder.remove();
+              placeholder = null;
+            }
+            setTimeout(() => { div.style.transition = ""; }, 600);
+          }, 300);
+        } else {
+          div.classList.remove("moving");
+          div.style.transform = "";
+          div.style.top = "";
+          div.style.left = "";
+        }
       };
 
       function mousemove (e : MouseEvent) {
-        div.classList.add("moving");
-        const rec = div.getBoundingClientRect();
-        if(e.clientY > rec.bottom) {
-          moveDown();
-        } else if (e.clientY < rec.top) {
-          moveUp();
+        if (!div.classList.contains("moving")) {
+          if (Math.abs(e.clientY - startMouseY) < 3) return;
+          const rect = div.getBoundingClientRect();
+          const containerRect = div.parentElement.getBoundingClientRect();
+          initialTop = rect.top - containerRect.top;
+          initialLeft = rect.left - containerRect.left;
+          grabOffsetY = startMouseY - rect.top;
+          div.classList.add("moving");
+          placeholder = document.createElement("div");
+          placeholder.className = "dropPlaceholder";
+          placeholder.style.height = rect.height + "px";
+          div.parentElement.insertBefore(placeholder, div);
+          div.style.top = initialTop + "px";
+          div.style.left = initialLeft + "px";
+        }
+
+        // Position: initial position + how far the mouse moved
+        const dy = e.clientY - startMouseY;
+        const dx = e.clientX - startMouseX;
+        div.style.top = (initialTop + dy) + "px";
+        div.style.left = (initialLeft + dx) + "px";
+        div.style.transform = `scale(0.96) rotate(1.5deg)`;
+
+        if (swapping) return;
+
+        // Use the cursor position for hit testing
+        const next = div.nextElementSibling as HTMLElement;
+        const previous = placeholder ? placeholder.previousElementSibling as HTMLElement : null;
+
+        if (next && !next.classList.contains("dropPlaceholder")) {
+          const nextRect = next.getBoundingClientRect();
+          const nextMid = nextRect.top + nextRect.height * 0.2;
+          if (e.clientY > nextMid) {
+            doSwap(next, "down");
+            return;
+          }
+        }
+        if (previous && !previous.classList.contains("dropPlaceholder")) {
+          const prevRect = previous.getBoundingClientRect();
+          const prevMid = prevRect.top + prevRect.height * 0.8;
+          if (e.clientY < prevMid) {
+            doSwap(previous, "up");
+          }
         }
       };
 
-      function moveDown () {
-        const next = div.nextElementSibling;
-        if(next) {
-          let ncurrentIndex = Number(next.getAttribute("currentIndex"));
-          ncurrentIndex --;
-          next.setAttribute("currentIndex", ncurrentIndex + "");
+      function doSwap(sibling: HTMLElement, direction: "up" | "down") {
+        swapping = true;
+        const siblingHeight = sibling.getBoundingClientRect().height;
 
-          div.parentElement.insertBefore(next, div);
-          let currentIndex = Number(div.getAttribute("currentIndex"));
-          currentIndex ++;
-          div.setAttribute("currentIndex", currentIndex + "");
+        // Update indices
+        let sIndex = Number(sibling.getAttribute("currentIndex"));
+        let dIndex = Number(div.getAttribute("currentIndex"));
+        if (direction === "down") {
+          sIndex--; dIndex++;
+        } else {
+          sIndex++; dIndex--;
         }
-      }
+        sibling.setAttribute("currentIndex", sIndex + "");
+        div.setAttribute("currentIndex", dIndex + "");
 
-      function moveUp () {
-        const previous = div.previousElementSibling;
-        if(previous) {
-          let pcurrentIndex = Number(previous.getAttribute("currentIndex"));
-          pcurrentIndex ++;
-          previous.setAttribute("currentIndex", pcurrentIndex + "");
-
-          div.parentElement.insertBefore(div, previous);
-          let currentIndex = Number(div.getAttribute("currentIndex"));
-          currentIndex --;
-          div.setAttribute("currentIndex", currentIndex + "");
+        // Move the placeholder (div stays absolute, unaffected by DOM order)
+        if (direction === "down") {
+          div.parentElement.insertBefore(sibling, placeholder);
+        } else {
+          div.parentElement.insertBefore(placeholder, sibling);
+          div.parentElement.insertBefore(div, sibling);
         }
+
+        // Animate the displaced sibling from its old position
+        const placeholderHeight = placeholder.getBoundingClientRect().height;
+        const fromOffset = direction === "down" ? placeholderHeight : -placeholderHeight;
+        sibling.classList.add("swapping");
+        sibling.style.transform = `translateY(${fromOffset}px)`;
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            sibling.style.transform = "";
+            sibling.addEventListener("transitionend", () => {
+              sibling.classList.remove("swapping");
+              swapping = false;
+            }, { once: true });
+            // Fallback in case transitionend doesn't fire
+            setTimeout(() => { swapping = false; }, 250);
+          });
+        });
       }
 
 
@@ -96,11 +214,38 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
       div.appendChild(div2);
 
       if (node.type.name != "questions") {
-        const remove = document.createElement("div");
-        remove.innerHTML = "х";
-        remove.className = "remove"
+        const remove = document.createElement("img");
+        remove.src = "/static/img/x.svg";
+        remove.className = "remove";
+        remove.draggable = false;
         remove.addEventListener("click", (e) => {
           container.removeChild(div);
+          // Create a removed entry
+          const removedDiv = document.createElement("div");
+          removedDiv.className = "studyBlock";
+          const removedName = document.createElement("div");
+          removedName.innerText = name;
+          removedName.style.textDecoration = "line-through";
+          removedDiv.appendChild(removedName);
+          const restoreBtn = document.createElement("div");
+          restoreBtn.className = "restore";
+          const restoreIcon = document.createElement("img");
+          restoreIcon.src = "/static/img/undo-icon.svg";
+          restoreIcon.draggable = false;
+          restoreBtn.appendChild(restoreIcon);
+          const restoreText = document.createElement("span");
+          restoreText.innerText = "Restore";
+          restoreBtn.appendChild(restoreText);
+          restoreBtn.addEventListener("click", () => {
+            removedList.removeChild(removedDiv);
+            if (removedList.children.length === 0) {
+              removedSection.style.display = "none";
+            }
+            container.appendChild(div);
+          });
+          removedDiv.appendChild(restoreBtn);
+          removedList.appendChild(removedDiv);
+          removedSection.style.display = "block";
         });
         div.appendChild(remove);
       }


### PR DESCRIPTION
Replaces the minimal study block editor with a fully redesigned modal that supports drag-and-drop reordering, block removal/restore, adding new blocks, and inline block renaming. Also redesigns the group study modal with an inline invite form.

## Reviewer notes

### Study block editor — drag-and-drop
The drag implementation uses `position: fixed` during the drag and a placeholder `div` to hold the vacated space, rather than the previous approach of swapping adjacent siblings. This is needed to support dragging across two separate lists (active vs. removed blocks) — the old sibling-swap approach can't span two containers.

### Study block editor — removed blocks
Removed blocks stay in the DOM in a "removed" section rather than being deleted immediately, letting users restore them before committing. The remove/restore buttons swap visibility in-place; the section itself is hidden when empty.

### Cross-list drag hysteresis
The mousemove handler uses a 10px hysteresis band when deciding whether to move the placeholder back from the removed list to the active list. Without this, the placeholder oscillates when the mouse is near the boundary because moving the placeholder changes the section's top position, immediately re-triggering the opposite condition.

### `abortDrag` on modal close
If the modal is closed (e.g., via the × button) during an active drag, `abortDrag` cleans up the `fixed`-positioned element and placeholder. Without this, the dragged item would be left floating.

### `startFixedTop` calculation
`startFixedTop = rect.top - (e.clientY - startMouseY)` anchors the element at its pre-drag screen position so it doesn't jump when the 3px threshold is crossed to start the drag.

### Block rename via textarea
Block names use a `<textarea rows="1">` instead of `<input>` so they auto-grow vertically for long names; `Enter` is suppressed since names are single-line.

### `withRenamedHeader` / `createGeneralStudyBlockNode`
New editorUtils helpers produce ProseMirror nodes for renamed and newly-created blocks. They live in editorUtils rather than StudyBlockEditor.ts because they operate on ProseMirror schema types and belong with the other schema utilities.

### Group study modal — inline invite form
The old flow opened a separate `/group_study/invite/:groupId` route to render an "Invite New People" view. The invite form is now embedded directly in `groupStudyHTML`, making `getInvite` and `getInviteNewMemberHTML` dead code — both are removed along with the route.

### Pencil icon changes
The gray circle background was removed and the stroke colour changed to blue (`#0057d1`) to match the new button style context the icon appears in.

### Cyrillic → Latin "x" in SidebarSections
The remove button was using a Cyrillic "х" (U+0445) that looks like Latin "x" but renders differently across fonts/OSes.

### Modal close buttons
All three modals (`#groupStudy` create, `#groupStudy` view, `#newStudy`) previously used bare `<img onclick>` for the close icon — not keyboard-accessible and invisible to screen readers. Changed to `<button aria-label="Close">` with a decorative `<img alt="">` child, matching the pattern already used in the study block editor modal.

### ProseMirror mousedown guards
Four places in Editor.tsx had `onclick` handlers on non-editable widgets without a `mousedown` guard. ProseMirror processes `mousedown` first, repositioning the cursor before the `click` handler fired. Adding `e.preventDefault()` on `mousedown` (and adding `"mousedown"` to `stopEvent` for the question-mark decoration) prevents the double cursor placement.