### PR TITLE
Redesign group study modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ result
 .devenv
 pg-init-*
 CLAUDE.md
+.claude
+.parcel-cache

--- a/backend/lib/Api/Htmx/GroupStudy.hs
+++ b/backend/lib/Api/Htmx/GroupStudy.hs
@@ -141,17 +141,9 @@ shareHTML isOwner share groupStudy = do
         | otherwise       = L.span_ [L.class_ "badge badge-pending"] "Invited"
   L.div_ [L.class_ "share person-row", L.id_ shareId] $ do
     L.div_ [L.class_ "person-info"] $ do
-      case share.userName of
-        Just name -> do
-          L.span_ [L.class_ "person-name"] $ do
-            L.toHtml name
-            statusBadge
-          L.span_ [L.class_ "person-email"] $
-            L.toHtml (CI.original (unwrap share.email))
-        Nothing -> do
-          L.span_ [L.class_ "person-name"] $ do
-            L.toHtml (CI.original (unwrap share.email))
-            statusBadge
+      L.span_ [L.class_ "person-name"] $ do
+        L.toHtml (CI.original (unwrap share.email))
+        statusBadge
     when isOwner $ do
       L.div_ [L.class_ "person-actions"] $ do
         let resendUrl =

--- a/backend/lib/Entity/Shares.hs
+++ b/backend/lib/Entity/Shares.hs
@@ -21,7 +21,6 @@ import Database.Beam (
   runSelectReturningOne,
   runUpdate,
   select,
-  subquery_,
   update,
   val_,
   (&&.),
@@ -314,11 +313,8 @@ getGroupShareData gsId = do
       share <- all_ Db.db.groupStudyShare
       guard_ $ share.groupStudyId ==. val_ gsId
       guard_ $ isNothing_ share.usedAt
-      let mName = subquery_ $ do
-                    u <- all_ Db.db.user
-                    guard_ $ u.email ==. share.email
-                    pure (just_ (u.name))
-      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created, mName)
+      mUser <- leftJoin_' (all_ Db.db.user) (\ u -> u.email ==?. share.email)
+      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created, mUser.name)
 
 
 getGroupShareDataByToken
@@ -347,11 +343,8 @@ getGroupShareDataByToken shareToken = do
       share <- all_ Db.db.groupStudyShare
       guard_ $ share.shareToken ==. val_ shareToken
       guard_ $ isNothing_ share.usedAt
-      let mName = subquery_ $ do
-                    u <- all_ Db.db.user
-                    guard_ $ u.email ==. share.email
-                    pure (just_ (u.name))
-      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created, mName)
+      mUser <- leftJoin_' (all_ Db.db.user) (\ u -> u.email ==?. share.email)
+      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created, mUser.name)
 
 
 deleteShare

--- a/backend/lib/Entity/Shares.hs
+++ b/backend/lib/Entity/Shares.hs
@@ -281,7 +281,6 @@ data GetShareData = MkGetShareData
   , isExpired :: Bool
   , rejected :: Bool
   , created :: UTCTime
-  , userName :: Maybe Text
   }
   deriving (Show, Generic)
   deriving anyclass (FromJSON, ToJSON, ToSchema)
@@ -295,7 +294,7 @@ getGroupShareData gsId = do
   now <- getCurrentTime
   fmap
     (fmap
-      (\(ex, token, email, r, cr, mName) ->
+      (\(ex, token, email, r, cr) ->
         MkGetShareData
           email
           token
@@ -303,7 +302,6 @@ getGroupShareData gsId = do
           (ex < now)
           r
           cr
-          mName
       )
     )
     $ runBeam
@@ -313,8 +311,7 @@ getGroupShareData gsId = do
       share <- all_ Db.db.groupStudyShare
       guard_ $ share.groupStudyId ==. val_ gsId
       guard_ $ isNothing_ share.usedAt
-      mUser <- leftJoin_' (all_ Db.db.user) (\ u -> u.email ==?. share.email)
-      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created, mUser.name)
+      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created)
 
 
 getGroupShareDataByToken
@@ -325,7 +322,7 @@ getGroupShareDataByToken shareToken = do
   now <- getCurrentTime
   fmap
     (fmap
-      (\(ex, token, email, r, cr, mName) ->
+      (\(ex, token, email, r, cr) ->
         MkGetShareData
           email
           token
@@ -333,7 +330,6 @@ getGroupShareDataByToken shareToken = do
           (ex < now)
           r
           cr
-          mName
       )
     )
     $ runBeam
@@ -343,8 +339,7 @@ getGroupShareDataByToken shareToken = do
       share <- all_ Db.db.groupStudyShare
       guard_ $ share.shareToken ==. val_ shareToken
       guard_ $ isNothing_ share.usedAt
-      mUser <- leftJoin_' (all_ Db.db.user) (\ u -> u.email ==?. share.email)
-      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created, mUser.name)
+      pure (share.expiresAt, share.shareToken, share.email, share.rejected, share.created)
 
 
 deleteShare

--- a/backend/lib/Entity/User.hs
+++ b/backend/lib/Entity/User.hs
@@ -32,6 +32,7 @@ data GetUser = MkGetUser
   { userId :: T.UserId
   , name :: Text
   , image :: Maybe Text
+  , email :: T.Email
   }
   deriving (Generic, Show)
   deriving (FromJSON, ToJSON, ToSchema)
@@ -43,6 +44,7 @@ instance E.Entity GetUser where
     { userId :: C f T.UserId
     , name :: C f Text
     , image :: C f (Maybe Text)
+    , email :: C f T.Email
     }
     deriving anyclass (Beamable)
     deriving (Generic)
@@ -54,6 +56,7 @@ instance E.Entity GetUser where
       userId
       name
       image
+      email
 
   queryEntity mAuthUser = do
     user <- all_ Db.db.user
@@ -65,6 +68,7 @@ instance E.Entity GetUser where
         user.userId
         user.name
         user.image
+        user.email
 
 type GetUser' = DbEntity GetUser Identity
 

--- a/backend/static/scripts/studyGroup.js
+++ b/backend/static/scripts/studyGroup.js
@@ -71,3 +71,22 @@ function findNextInput (elem) {
     nextInput.focus()
   }
 }
+
+// Inline invite form in the group study modal
+document.addEventListener("htmx:afterSettle", function(evt) {
+  const dialog = document.getElementById("groupStudy");
+  if (!dialog || !dialog.open) return;
+  const emailInput = dialog.querySelector('input[name="email[]"]');
+  if (!emailInput) return;
+  emailInput.focus();
+  if (!emailInput._inviteHandlerAttached) {
+    emailInput._inviteHandlerAttached = true;
+    emailInput.addEventListener("keydown", function(e) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        htmx.trigger(emailInput.closest("form"), "submit");
+      }
+    });
+  }
+});

--- a/backend/static/styles/component/groupstudy.css
+++ b/backend/static/styles/component/groupstudy.css
@@ -2,29 +2,99 @@
   background-color: #fff;
   border-radius: 8px;
   width: 100vw;
-  max-width: 520px;
+  max-width: 570px;
   min-height: 10px;
-  padding: 20px;
+  padding: 24px;
   overflow-y: auto;
   box-shadow: 0 4px 6px #0000001a;
   border: none;
   box-sizing: border-box;
+  position: relative;
+
+  .closeModalIcon {
+    cursor: pointer;
+    max-width: 20px;
+    padding: 10px;
+    position: absolute;
+    top: 12px;
+    right: 12px;
+  }
+
+  .field-label {
+    color: #666;
+    font-size: 16px;
+    font-weight: 500;
+    margin-bottom: 5px;
+    display: block;
+  }
+
+  .field-desc {
+    color: #aaa;
+    font-size: 14px;
+    margin: -2px 0 8px;
+    line-height: 1.4;
+  }
+
+  /* Shared p-select base styles */
+  p-select::part(p-select) {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 0 6px;
+    font-size: 14px;
+    box-sizing: border-box;
+  }
+  p-select::part(p-select):hover {
+    background-color: #f5f5f5;
+  }
+  p-select::part(p-dropbox) {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px #0000001a;
+    min-width: 220px;
+  }
+  p-select::part(p-option) {
+    padding: 8px 10px;
+    font-size: 14px;
+  }
+
   .groupStudyEditorHolder {
     flex-direction: column;
     align-items: stretch;
     width: 100%;
     display: flex;
     gap: 5px;
+
+    .groupStudy-header {
+      margin-bottom: 4px;
+      h3 {
+        margin: 0;
+        padding-right: 30px;
+      }
+    }
+
     .groupStudyName {
       display: grid;
-      grid-template-columns: 1fr 100px;
+      grid-template-columns: 1fr auto;
+      align-items: start;
+      margin-top: 4px;
       input {
         margin: 0;
+        height: 36px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 0 12px;
+        font-size: 14px;
+        box-sizing: border-box;
+        font-family: inherit;
+        min-width: 0;
       }
-
       .saving-box {
         justify-self: end;
         align-self: center;
+        font-size: 13px;
+        color: #888;
         .saving-indicator {
           display: none;
         }
@@ -36,45 +106,160 @@
         }
       }
     }
-    .trash {
-      align-content: center;
-      display: flex;
-      height: 35px;
+
+    .groupStudy-name-readonly {
+      font-size: 15px;
+      font-weight: 500;
+      color: #222;
+      margin: 4px 0 0;
     }
-    .expired {
-      color: red;
-      font-size: 0.7em;
-    }
-    .buttons {
-      display: flex;
-      justify-content: end;
-      gap: 3px;
-    }
-    .share {
-      display: grid;
-      grid-template-columns: 1fr 150px;
-      padding-bottom: 4px;
-      .share-email {
-        align-content: center;
+
+    .groupStudy-section {
+      margin-top: 4px;
+      .field-label {
+        margin-bottom: 2px;
       }
     }
-    label {
-      color: #666;
-      font-size: 16px;
+
+    .ghost-blue {
+      background: none;
+      color: var(--blue-100, #1a73e8);
+      font-size: 13px;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 4px;
+      &:hover {
+        background-color: var(--blue-25, #e8f0fe);
+      }
     }
+
+    .groupStudy-invite-row {
+      display: grid;
+      grid-template-columns: 1fr 110px auto;
+      gap: 5px;
+      align-items: center;
+      input[type="email"] {
+        height: 36px;
+        margin: 0;
+        font-size: 14px;
+      }
+      p-select::part(p-select) {
+        width: 100%;
+        height: 36px;
+      }
+      button {
+        height: 36px;
+        white-space: nowrap;
+      }
+    }
+
+    .groupStudy-divider {
+      border: none;
+      border-top: 1px solid #e0e0e0;
+      margin: 12px 0 8px;
+    }
+
+    .groupStudy-people {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .person-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      padding: 6px 0;
+      align-items: center;
+    }
+
+    .person-info {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      min-width: 0;
+    }
+
+    .person-name {
+      font-size: 14px;
+      font-weight: 500;
+      color: #222;
+      display: flex;
+      align-items: baseline;
+      gap: 4px;
+      flex-wrap: wrap;
+    }
+
+    .you-label {
+      color: #888;
+      font-weight: 400;
+    }
+
+    .person-role {
+      font-size: 12px;
+      color: #888;
+      font-weight: 400;
+    }
+
+    .person-email {
+      font-size: 12px;
+      color: #888;
+    }
+
+    .person-actions {
+      display: flex;
+      justify-content: end;
+      gap: 4px;
+      align-items: center;
+    }
+
+    .badge {
+      font-size: 11px;
+      padding: 1px 8px;
+      border-radius: 8px;
+      font-weight: 500;
+    }
+    .badge-pending {
+      background-color: #e8f0fe;
+      color: #1a73e8;
+    }
+    .badge-error {
+      background-color: #fce8e6;
+      color: #d93025;
+    }
+
+    .remove-btn {
+      background: none;
+      color: #888;
+      font-size: 13px;
+      font-weight: 400;
+      padding: 4px 8px;
+      border-radius: 4px;
+      &:hover {
+        color: var(--red-100);
+        background-color: var(--red-25);
+      }
+    }
+
+    .share .person-info {
+      flex-direction: row;
+      align-items: center;
+      gap: 8px;
+    }
+
     input {
       margin-bottom: 10px;
     }
 
     .member {
-      display: grid;
-      grid-template-columns: 1fr 150px;
-      padding-bottom: 4px;
-      div {
-        align-content: center;
-      }
       p-select::part(p-select) {
         height: 100%;
+        font-size: 13px;
+      }
+      p-select::part(p-dropbox) {
+        right: 0;
+      }
+      p-select::part(p-option) {
+        font-size: 13px;
       }
     }
   }
@@ -88,10 +273,10 @@
     display: grid;
     grid-row-gap: 10px;
   }
-  .peopleInput{
+  .peopleInput {
     display: grid;
     height: 2em;
-    grid-template-columns: 1fr 100px 40px;
+    grid-template-columns: 1fr 110px 40px;
     grid-column-gap: 3px;
     input {
       height: 100%;
@@ -100,18 +285,9 @@
       width: 100%;
       height: 100%;
     }
-    p-select::part(p-option) {
-      height: 2em;
-    }
-  }
-
-  h4 {
-    margin-top: 10px;
   }
 
   #studyGroupDeletes {
     display: none;
   }
-
 }
-

--- a/backend/templates/study.html
+++ b/backend/templates/study.html
@@ -331,7 +331,7 @@
       <header>
         <h2>Edit Study Blocks</h2>
         <div style="color:gray">
-          Click and grad to move the study blocks around.
+          Click and drag to move the study blocks around.
         </div>
       </header>
       <div id="studyBlockEditorContent">

--- a/frontend/src/SidebarSections.ts
+++ b/frontend/src/SidebarSections.ts
@@ -61,8 +61,6 @@ function createSectionHeader(editor : Editor.P215Editor, index : number) {
 
   const remove = document.createElement("div");
   remove.innerHTML = "х";
-  // const img = document.createElement("img");
-  // img.src = "/static/img/x.svg";
   remove.className = "remove";
   remove.addEventListener("click", (e) => {
     e.stopPropagation();

--- a/frontend/src/StudyBlockEditor.ts
+++ b/frontend/src/StudyBlockEditor.ts
@@ -33,7 +33,6 @@ document.addEventListener("editorAttached", (ev : Editor.EditorAttached) => {
         document.removeEventListener("mouseup", mouseup);
         document.removeEventListener("mousemove", mousemove);
         div.classList.remove("moving");
-        let currentIndex = Number(div.getAttribute("currentIndex"));
       };
 
       function mousemove (e : MouseEvent) {


### PR DESCRIPTION
## Summary
- Replace the separate invite page with an inline invite form on the main group study modal
- Show members and invitees in a unified people list with names, emails, status badges (Invited/Expired/Rejected), and action buttons
- Add close button and descriptive help text to the create and manage modals
- Look up invited user names via subquery so shares display real names when available
- Consolidate duplicated p-select CSS into shared base styles