### PR TITLE
Fix verse superscript click using getPos() instead of stale position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ result
 .devenv
 pg-init-*
 CLAUDE.md
+.claude
+.parcel-cache


### PR DESCRIPTION
## Summary

- Verse reference widget was capturing position at decoration-creation time, which became stale after document edits
- Now uses ProseMirror's `getPos()` callback to get the current position at click time
- Added `stopEvent` to prevent ProseMirror from swallowing mousedown/click events on the widget
- Switched from `onclick` to `onmousedown` and removed unnecessary `contentEditable` on the span