### PR TITLE
Fix mobile keyboard/viewport jank on editor page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ result
 .devenv
 pg-init-*
 CLAUDE.md
+.claude
+.parcel-cache

--- a/backend/static/styles/editor/toolbar.css
+++ b/backend/static/styles/editor/toolbar.css
@@ -8,6 +8,9 @@
   display: flex;
   position: sticky;
   top: 52px;
+  overflow-x: auto;
+  touch-action: pan-x;
+  overscroll-behavior: contain;
 
   .tooltipContainer {
     cursor: pointer;

--- a/backend/static/styles/header.css
+++ b/backend/static/styles/header.css
@@ -10,6 +10,7 @@
   position: sticky;
   box-shadow: 0 2px 4px #0003;
   top: 0px;
+  touch-action: none;
   .logo {
     max-height: 40px;
   }

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -23,7 +23,6 @@ html:has(#studyPage) body {
   grid-template-rows: 52px 34px 1fr;
   overflow: hidden;
   overscroll-behavior: none;
-  touch-action: none;
 
   &.collapseSide{
     grid-template-columns: 60px 1fr;

--- a/backend/static/styles/pages/study.css
+++ b/backend/static/styles/pages/study.css
@@ -6,13 +6,24 @@
 @import url("../editor/toolbar.css");
 @import url("../component/nav.css");
 
+html:has(#studyPage),
+html:has(#studyPage) body {
+  overflow: hidden;
+  overscroll-behavior: none;
+  height: 100%;
+}
+
 #studyPage {
   display: grid;
   height: 100vh;
+  height: 100dvh;
+  height: var(--vh-real, 100dvh);
   grid-template-areas: "header header" "toolbar toolbar" "sidebar editor";
   grid-template-columns: 200px 1fr;
   grid-template-rows: 52px 34px 1fr;
   overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
 
   &.collapseSide{
     grid-template-columns: 60px 1fr;
@@ -76,6 +87,8 @@
       display: grid;
       grid-template-rows: 2.2rem 1fr 2.2rem;
       height: calc(100vh - 6rem);
+      height: calc(100dvh - 6rem);
+      height: calc(var(--vh-real, 100dvh) - 6rem);
     }
     #collapseSide {
       display: flex;

--- a/backend/static/styles/utils/base.css
+++ b/backend/static/styles/utils/base.css
@@ -147,6 +147,8 @@ dialog.popup {
   overflow-y: auto;
   align-self: stretch;
   justify-self: stretch;
+  touch-action: pan-y;
+  overscroll-behavior: contain;
 }
 
 

--- a/frontend/src/Editor/Editor.tsx
+++ b/frontend/src/Editor/Editor.tsx
@@ -1297,6 +1297,8 @@ export class P215Editor extends EventTarget {
     this.view = new EditorView(editorRoot, {
       state: that.state,
       editable: () => that.editable,
+      scrollThreshold: { top: 100, bottom: 100, left: 0, right: 0 },
+      scrollMargin: { top: 100, bottom: 100, left: 0, right: 0 },
       handlePaste: this.handlePaste.bind(this),
       handleDOMEvents: {
         focus: () => {

--- a/frontend/src/SidebarSections.ts
+++ b/frontend/src/SidebarSections.ts
@@ -143,7 +143,6 @@ function createSectionHeader(editor : Editor.P215Editor, index : number) {
   });
 
   section.addEventListener("touchstart", (e : TouchEvent) => {
-    e.preventDefault();
     closeAllDeleters(section);
     const startTime = e.timeStamp;
     let state : TouchStates = {
@@ -165,6 +164,7 @@ function createSectionHeader(editor : Editor.P215Editor, index : number) {
       clearTimeout(moveTimeout);
       switch (state.currentGesture) {
         case "Moving": {
+          e2.preventDefault();
           const rec = section.getBoundingClientRect();
           const touch = e2.touches[0];
           if (touch.clientY > rec.bottom) {
@@ -175,6 +175,7 @@ function createSectionHeader(editor : Editor.P215Editor, index : number) {
           break;
         }
         case "Swipe": {
+          e2.preventDefault();
           const touch = e2.touches[0];
           let moveX = touch.clientX - state.swipeState.initialTouch.clientX;
           section.style.transform = `translateX(${moveX}px)`;
@@ -228,8 +229,12 @@ function createSectionHeader(editor : Editor.P215Editor, index : number) {
         }
         case "None": {
           const endTime = e2.timeStamp;
-          // A tap
-          if(endTime - startTime < 100) {
+          const endTouch = e2.changedTouches[0];
+          const dX = endTouch.clientX - state.swipeState.initialTouch.clientX;
+          const dY = endTouch.clientY - state.swipeState.initialTouch.clientY;
+          const dist = Math.sqrt(dX * dX + dY * dY);
+          // A tap: short duration and barely moved
+          if(endTime - startTime < 300 && dist < 10) {
             const currentIndex = section.getAttribute("currentIndex")
             editor.scrollTo(Number(currentIndex));
           }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,4 +1,5 @@
 
+import { initViewportStabilizer } from "./viewportStabilizer"
 import * as EActions from "./Editor/editorUtils"
 import * as Editor from "./Editor/Editor"
 import * as WS from "./WebsocketTypes"
@@ -150,17 +151,4 @@ function mkSaveObject (ws : WS.MyWebsocket) {
 
 GS.init(ws);
 
-// window.visualViewport.addEventListener("resize", () => {
-//   const viewPort = document.querySelector("meta[name=viewport]");
-//   let map = {};
-//   viewPort.getAttribute("content").split(",").forEach( (t) => {
-//     const [key, value] = t.split("=");
-//     map[key.trim()] = value;
-//   });
-//   map["height"] = window.visualViewport.height + "";
-//   const newContent = Object.keys(map).map( (key) => {
-//     return key + "=" + map[key];
-//   }).join(", ");
-//   viewPort.setAttribute("content", newContent);
-//   console.log(newContent);
-// });
+initViewportStabilizer();

--- a/frontend/src/viewportStabilizer.ts
+++ b/frontend/src/viewportStabilizer.ts
@@ -1,0 +1,22 @@
+// Sets --vh-real CSS variable on <html> to the visual viewport height,
+// covering mobile browsers where 100dvh doesn't update for keyboard/address-bar changes.
+export function initViewportStabilizer(): void {
+  const vv = window.visualViewport;
+  if (!vv) return;
+
+  let raf: number | null = null;
+
+  function update() {
+    raf = null;
+    document.documentElement.style.setProperty('--vh-real', `${vv.height}px`);
+  }
+
+  function onResize() {
+    if (raf) return;
+    raf = requestAnimationFrame(update);
+  }
+
+  vv.addEventListener('resize', onResize);
+  vv.addEventListener('scroll', onResize);
+  update();
+}


### PR DESCRIPTION
## Summary

- Replace `100vh` on the study page grid with a `100vh → 100dvh → var(--vh-real)` cascade so the editor container shrinks correctly when the mobile keyboard opens
- Add a lightweight `VisualViewport` listener that sets a `--vh-real` CSS variable as progressive enhancement for browsers where `dvh` alone isn't sufficient
- Lock body/html scrolling on the study page and scope `touch-action` per element: `none` on header, `pan-x` on toolbar (enabling horizontal swipe), `pan-y` on editor scroll container
- Add ProseMirror `scrollThreshold`/`scrollMargin` so the cursor stays visible above the keyboard and below the 86px header+toolbar
- Fix sidebar touch scrolling: defer `preventDefault()` in `SidebarSections.ts` until the gesture is confirmed as drag-to-reorder or swipe-to-delete, so native scroll works
- Add distance check to sidebar tap detection so flick-scroll gestures don't trigger section navigation
- Make toolbar horizontally scrollable on narrow screens via `overflow-x: auto`
- Remove old commented-out `visualViewport` hack from `index.tsx`