### PR TITLE
Fix character insertion before verse superscript

### DIFF
--- a/frontend/src/Editor/textSchema.ts
+++ b/frontend/src/Editor/textSchema.ts
@@ -251,6 +251,7 @@ export const textSchema = new Schema({
     },
     verse: {
       attrs: { book: {}, chapter: {}, verse: {} },
+      inclusive: false,
       toDOM: (mark) => {
         return [
           "span",


### PR DESCRIPTION
## Summary

Fixes a bug where typing a character just before a verse number superscript would cause the character to appear after the superscript instead of before it. One-line change to the verse mark schema.

## Q&A for reviewers

**Why `inclusive: false` on the verse mark?**
ProseMirror marks default to `inclusive: true`, which means a mark extends to cover characters typed at its boundaries. When the cursor was at the start of verse-marked text (immediately after the superscript widget), typing a character gave it the verse mark. The decoration plugin then placed the superscript widget before this new first verse-marked character — so the typed character ended up after the verse number visually. Setting `inclusive: false` prevents the mark from spreading to boundary-typed characters: the new character has no verse mark, the verse text shifts one position right, and the widget rebuilds after the new character.

**Why not also change `side` on the widget decoration?**
The widget's `side: -1` is correct — it anchors the widget visually before the verse text. The real source of the bug was mark inheritance, not widget placement. Fixing `inclusive` is sufficient and more semantically correct: verse marks represent fixed Bible text attribution and should never spread to user-typed content.