### PR TITLE
Add Cmd+Shift+Z as redo keybinding

### DIFF
--- a/frontend/src/Editor/Editor.tsx
+++ b/frontend/src/Editor/Editor.tsx
@@ -638,6 +638,7 @@ const questionPopup = (
           keymap({
             "Mod-z": undo,
             "Mod-y": redo,
+            "Mod-Shift-z": redo,
             Tab: increaseLevel,
             "Mod-]": increaseLevel,
             "Shift-Tab": decreaseLevel,
@@ -1260,6 +1261,7 @@ export class P215Editor extends EventTarget {
         keymap({
           "Mod-z": undo,
           "Mod-y": redo,
+          "Mod-Shift-z": redo,
           Tab: increaseLevel,
           "Mod-]": increaseLevel,
           "Shift-Tab": decreaseLevel,


### PR DESCRIPTION
Adds `Mod-Shift-Z` (Cmd+Shift+Z on macOS, Ctrl+Shift+Z on Windows/Linux) as a redo shortcut in the editor. This is the standard redo binding on macOS and complements the existing `Mod-Y` binding.

## Reviewer notes

**Why two identical changes?**
The editor has two separate keymap registrations — one in `questionPopup` and one in `P215Editor` — so the binding must be added to both to work in all editor contexts.

**Why keep `Mod-Y` as well?**
`Ctrl+Y` is the conventional redo shortcut on Windows; removing it would break that expectation.